### PR TITLE
Expose shader category to GUI

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -81,9 +81,10 @@ void CDialogGameVideoFilter::GetItems(CFileItemList &items)
   for (const auto &videoFilter : m_videoFilters)
   {
     auto localizedName = GetLocalizedString(videoFilter.nameIndex);
-    auto localizedCategory = GetLocalizedString(videoFilter.categoryIndex); // TODO
+    auto localizedCategory = GetLocalizedString(videoFilter.categoryIndex);
 
     CFileItemPtr item = std::make_shared<CFileItem>(localizedName);
+    item->SetLabel2(localizedCategory);
     items.Add(std::move(item));
   }
 


### PR DESCRIPTION
FileItems can have a "label2". In this case, the "label2" is displayed in the skin here: https://github.com/garbear/xbmc/blob/c28de0f/addons/skin.estuary/xml/GameOSDVideoSelect.xml#L53

IMO name and category should be swapped.