### PR TITLE
Remove circular dependency

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -552,6 +552,7 @@ const uint64_t* CRetroPlayer::GetTotalFrameCountPointer()
 void CRetroPlayer::OnSpeedChange(double newSpeed)
 {
   m_audio->Enable(newSpeed == 1.0);
+  m_renderManager->SetSpeed(newSpeed);
   m_processInfo->SetSpeed(newSpeed);
   if (newSpeed != 0.0)
     CloseOSD();

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -173,6 +173,12 @@ void CRPRenderManager::FrameMove()
   ManageCaptures();
 }
 
+void CRPRenderManager::SetSpeed(double speed)
+{
+  if (m_pRenderer)
+    m_pRenderer->SetSpeed(speed);
+}
+
 // Implementation of IVideoSelectCallback
 
 bool CRPRenderManager::SupportsScalingMethod(ESCALINGMETHOD method)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -38,6 +38,7 @@ namespace RETRO
     bool Configure();
     bool Configure(const VideoPicture& picture, float fps, unsigned flags, unsigned int orientation, int buffers = 0);
     void FrameMove();
+    void SetSpeed(double speed);
 
     // Implementation of IVideoSelectCallback
     bool SupportsScalingMethod(ESCALINGMETHOD method) override;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -49,6 +49,12 @@ CBaseRenderer* CRPWinRenderer::Create(CVideoBuffer *buffer)
   return new CRPWinRenderer();
 }
 
+void CRPWinRenderer::SetSpeed(double speed)
+{
+  if (m_shaderManager)
+    m_shaderManager->SetSpeed(speed);
+}
+
 void CRPWinRenderer::Render(DWORD flags, CD3DTexture* target)
 {
   if (!m_renderBuffers[m_iYV12RenderBuffer].loaded)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -58,6 +58,9 @@ public:
 //  bool WantsDoublePass() override;
 //  bool ConfigChanged(const VideoPicture& picture) override;
 
+  //! @todo Remove me
+  void SetSpeed(double speed) override;
+
 protected:
   void Render(DWORD flags, CD3DTexture* target) override;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -28,7 +28,6 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 
 #include <regex>
-#include "Application.h"
 #include "cores/RetroPlayer/RetroPlayer.h"
 
 using namespace SHADER;
@@ -89,7 +88,7 @@ void CVideoShaderManager::Render(CRect sourceRect, CPoint dest[], CD3DTexture& t
   SetCommonShaderParams(lastShader, lastTexture);
   lastShader.Render(lastTexture, target);
 
-  if(!g_application.m_pPlayer->IsPaused())
+  if (m_speed != 0.0)
     ++m_frameCount;
 
   // Restore our view port.

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
@@ -45,6 +45,8 @@ public:
 
   void SetViewPort(const CRect& viewPort);
 
+  void SetSpeed(double speed) { m_speed = speed; }
+
 protected:
   void SetCommonShaderParams(CVideoShader& shader, CD3DTexture& texture);
 
@@ -125,4 +127,6 @@ private:
   CPoint m_dest[4];
 
   cbInput GetInputData();
+
+  double m_speed = 0.0;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -102,6 +102,9 @@ public:
 
   static void SettingOptionsRenderMethodsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
+  //! @todo Remove me
+  virtual void SetSpeed(double speed) { }
+
 protected:
   void CalcNormalRenderRect(float offsetX, float offsetY, float width, float height,
                             float inputFrameRatio, float zoomAmount, float verticalShift);


### PR DESCRIPTION
CApplication owns the player, so the player shouldn't depend on CApplication.

The `todos` can be removed when the VideoShaderManager isn't owned by the renderer.