### PR TITLE
RetroPlayer: Encapsulate shader presets

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -147,7 +147,7 @@ bool CServiceManager::InitStageThree()
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
 
-  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager, *m_peripherals));
+  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager, *m_peripherals, *m_addonMgr, *m_binaryAddonManager));
 
   m_contextMenuManager->Init();
   m_PVRManager->Init();

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -53,49 +53,49 @@ const char* CShaderPresetAddon::GetLibraryBasePath()
 }
 
 
-config_file_t_ *CShaderPresetAddon::ConfigFileNew(const char *path)
+config_file *CShaderPresetAddon::ConfigFileNew(const char *path)
 {
   m_strConfigPath = URIUtils::AddFileToFolder(GetLibraryBasePath(), path);
   m_strConfigBasePath = URIUtils::GetBasePath(m_strConfigPath);
   return m_struct.toAddon.config_file_new(&m_struct, m_strConfigPath.c_str(), m_strConfigBasePath.c_str());
 }
 
-config_file_t_ *CShaderPresetAddon::ConfigFileNewFromString(const char *from_string)
+config_file *CShaderPresetAddon::ConfigFileNewFromString(const char *from_string)
 {
   return m_struct.toAddon.config_file_new_from_string(&m_struct, from_string);
 }
 
-void CShaderPresetAddon::ConfigFileFree(config_file_t_ *conf)
+void CShaderPresetAddon::ConfigFileFree(config_file *conf)
 {
   return m_struct.toAddon.config_file_free(&m_struct, conf);
 }
 
-bool CShaderPresetAddon::ShaderPresetRead(config_file_t_ *conf, video_shader_ *shader)
+bool CShaderPresetAddon::ShaderPresetRead(config_file *conf, video_shader *shader)
 {
   return m_struct.toAddon.video_shader_read_conf_cgp(&m_struct, conf, shader);
 }
 
-void CShaderPresetAddon::ShaderPresetWrite(config_file_t_ *conf, video_shader_ *shader)
+void CShaderPresetAddon::ShaderPresetWrite(config_file *conf, video_shader *shader)
 {
   return m_struct.toAddon.video_shader_write_conf_cgp(&m_struct, conf, shader);
 }
 
-void CShaderPresetAddon::ShaderPresetResolveRelative(video_shader_ *shader, const char *ref_path)
+void CShaderPresetAddon::ShaderPresetResolveRelative(video_shader *shader, const char *ref_path)
 {
   return m_struct.toAddon.video_shader_resolve_relative(&m_struct, shader, ref_path);
 }
 
-bool CShaderPresetAddon::ShaderPresetResolveCurrentParameters(config_file_t_ *conf, video_shader_ *shader)
+bool CShaderPresetAddon::ShaderPresetResolveCurrentParameters(config_file *conf, video_shader *shader)
 {
   return m_struct.toAddon.video_shader_resolve_current_parameters(&m_struct, conf, shader);
 }
 
-bool CShaderPresetAddon::ShaderPresetResolveParameters(config_file_t_ *conf, video_shader_ *shader)
+bool CShaderPresetAddon::ShaderPresetResolveParameters(config_file *conf, video_shader *shader)
 {
   return m_struct.toAddon.video_shader_resolve_parameters(&m_struct, conf, shader);
 }
 
-void CShaderPresetAddon::VideoShaderFree(video_shader_ *shader)
+void CShaderPresetAddon::VideoShaderFree(video_shader *shader)
 {
   return m_struct.toAddon.video_shader_free(&m_struct, shader);
 }

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -148,6 +148,8 @@ bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, KODI::SHADER:
       }
       shaderPresetAddon->FreeShaderPreset(videoShader);
     }
+
+    m_struct.toAddon.config_file_free(&m_struct, file);
   }
 
   return bSuccess;

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -19,12 +19,14 @@
  */
 
 #include "ShaderPreset.h"
+#include "addons/binary-addons/BinaryAddonBase.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/log.h"
 #include "utils/URIUtils.h"
 
-using namespace KODI;
-using namespace SHADERPRESET;
+using namespace ADDON;
 
-CShaderPresetAddon::CShaderPresetAddon(const ADDON::BinaryAddonBasePtr& addonBase)
+CShaderPresetAddon::CShaderPresetAddon(const BinaryAddonBasePtr& addonBase)
   : IAddonInstanceHandler(ADDON_INSTANCE_SHADERPRESET, addonBase)
 {
   ResetProperties();
@@ -33,6 +35,28 @@ CShaderPresetAddon::CShaderPresetAddon(const ADDON::BinaryAddonBasePtr& addonBas
 CShaderPresetAddon::~CShaderPresetAddon(void)
 {
   DestroyAddon();
+}
+
+bool CShaderPresetAddon::CreateAddon(void)
+{
+  CExclusiveLock lock(m_dllSection);
+
+  // Reset all properties to defaults
+  ResetProperties();
+
+  // Initialise the add-on
+  CLog::Log(LOGDEBUG, "%s - creating ShaderPreset add-on instance '%s'", __FUNCTION__, Name().c_str());
+
+  if (CreateInstance(&m_struct) != ADDON_STATUS_OK)
+    return false;
+
+  return true;
+}
+
+void CShaderPresetAddon::DestroyAddon()
+{
+  CExclusiveLock lock(m_dllSection);
+  DestroyInstance();
 }
 
 void CShaderPresetAddon::ResetProperties(void)
@@ -51,7 +75,6 @@ const char* CShaderPresetAddon::GetLibraryBasePath()
   }
   return m_strLibraryPath.c_str();
 }
-
 
 config_file *CShaderPresetAddon::ConfigFileNew(const char *path)
 {

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -23,18 +23,16 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 #include "threads/CriticalSection.h"
 #include "threads/SharedSection.h"
-#include "filesystem/SpecialProtocol.h"
-#include "binary-addons/BinaryAddonBase.h"
 
-namespace SHADERPRESET
+namespace ADDON
 {
   /*
    *  Wrapper class that wraps the shader presets add-on
    */
-  class CShaderPresetAddon : public ADDON::IAddonInstanceHandler
+  class CShaderPresetAddon : protected IAddonInstanceHandler
   {
   public:
-    CShaderPresetAddon(const ADDON::BinaryAddonBasePtr& addonInfo);
+    CShaderPresetAddon(const BinaryAddonBasePtr& addonInfo);
     ~CShaderPresetAddon(void) override;
 
     /*!
@@ -148,4 +146,4 @@ namespace SHADERPRESET
 
     CSharedSection      m_dllSection;
   };
-} // namespace SHADERPRESET
+}

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -84,17 +84,13 @@ namespace ADDON
      */
     void DestroyAddon();
 
+    /*!
+     * \brief Get the shader preset extensions supported by this add-on
+     */
+    const std::vector<std::string> &GetExtensions() const { return m_extensions; }
+
     // implementation of IVideoShaderPresetLoader
     bool LoadPreset(const std::string &presetPath, KODI::SHADER::VideoShaderPreset &shaderPreset) override;
-
-    /**
-     * GetLibraryBasePath:
-     * @brief Returns the full/absolute path of the dynamic library file.
-     *
-     */
-    const char* GetLibraryBasePath(void);
-
-    const std::vector<std::string> &GetExtensions() const { return m_extensions; }
 
   private:
     /*!
@@ -103,6 +99,12 @@ namespace ADDON
     void ResetProperties(void);
 
     static void TranslateShaderPreset(const video_shader &shader, KODI::SHADER::VideoShaderPreset &shaderPreset);
+    static void TranslateShaderPass(const video_shader_pass &pass, KODI::SHADER::VideoShaderPass &shaderPass);
+    static void TranslateShaderLut(const video_shader_lut &lut, KODI::SHADER::VideoShaderLut &shaderLut);
+    static void TranslateShaderParameter(const video_shader_parameter &param, KODI::SHADER::VideoShaderParameter &shaderParam);
+    static KODI::SHADER::FILTER_TYPE TranslateFilterType(SHADER_FILTER_TYPE type);
+    static KODI::SHADER::WRAP_TYPE TranslateWrapType(SHADER_WRAP_TYPE type);
+    static KODI::SHADER::SCALE_TYPE TranslateScaleType(SHADER_SCALE_TYPE type);
 
     /* @brief Cache for const char* members in PERIPHERAL_PROPERTIES */
 

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -26,6 +26,39 @@
 
 namespace ADDON
 {
+  class CShaderPreset;
+  using ShaderPresetPtr = std::shared_ptr<CShaderPreset>;
+
+  class CShaderPreset
+  {
+  public:
+    CShaderPreset(config_file *file, AddonInstance_ShaderPreset &instanceStruct);
+    ~CShaderPreset();
+
+    /*!
+     * \brief @todo document
+     */
+    bool ReadShaderPreset(video_shader &shader);
+
+    /*!
+    * \brief @todo document
+    */
+    void WriteShaderPreset(const video_shader &shader);
+
+    //void ResolveRelative(video_shader &shader, const std::string &ref_path);
+
+    //bool ResolveCurrentParameters(video_shader &shader);
+
+    /*!
+    * \brief @todo document
+    */
+    bool ResolveParameters(video_shader &shader);
+
+  private:
+    config_file *m_file;
+    AddonInstance_ShaderPreset &m_struct;
+  };
+
   /*
    *  Wrapper class that wraps the shader presets add-on
    */
@@ -36,7 +69,7 @@ namespace ADDON
     ~CShaderPresetAddon(void) override;
 
     /*!
-     * @brief Initialise the instance of this add-on
+     * \brief Initialise the instance of this add-on
      */
     bool CreateAddon(void);
 
@@ -45,81 +78,16 @@ namespace ADDON
      */
     void DestroyAddon();
 
-    /// ======== config_file_ ========
-
-    /* Loads a config file. Returns NULL if file doesn't exist.
-     * NULL path will create an empty config file. */
-    config_file* ConfigFileNew(const char *path);
-
-    /* Load a config file from a string. */
-    config_file* ConfigFileNewFromString(const char *from_string);
-
-    /* Frees config file. */
-    void ConfigFileFree(config_file *conf);
-
-    /// ==== video_shader_PARSE =====
-
-    /**
-     * ShaderPresetRead:
-     * @conf              : Preset file to read from.
-     * @shader            : Shader passes handle.
-     *
-     * Loads preset file and all associated state (passes,
-     * textures, imports, etc).
-     *
-     * Returns: true (1) if successful, otherwise false (0).
-     **/
-    bool ShaderPresetRead(config_file* conf, video_shader* shader);
-
-    /**
-     * ShaderPresetWrite:
-     * @conf              : Preset file to read from.
-     * @shader            : Shader passes handle.
-     *
-     * Saves preset and all associated state (passes,
-     * textures, imports, etc) to disk.
-     **/
-    void ShaderPresetWrite(config_file *conf, struct video_shader *shader);
-
-    /**
-     * ShaderPresetResolveRelative:
-     * @shader            : Shader pass handle.
-     * @ref_path          : Relative shader path.
-     *
-     * Resolves relative shader path (@ref_path) into absolute
-     * shader paths.
-     **/
-    void ShaderPresetResolveRelative(struct video_shader *shader, const char *ref_path);
-
-    /**
-     * ShaderPresetResolveCurrentParameters:
-     * @conf              : Preset file to read from.
-     * @shader            : Shader passes handle.
-     *
-     * Reads the current value for all parameters from config file.
-     *
-     * Returns: true (1) if successful, otherwise false (0).
-     **/
-    bool ShaderPresetResolveCurrentParameters(config_file *conf, struct video_shader *shader);
-
-    /**
-     * ShaderPresetResolveParameters:
-     * @conf              : Preset file to read from.
-     * @shader            : Shader passes handle.
-     *
-     * Resolves all shader parameters belonging to shaders.
-     *
-     * Returns: true (1) if successful, otherwise false (0).
-     **/
-    bool ShaderPresetResolveParameters(config_file *conf, struct video_shader *shader);
-
-    void VideoShaderFree(video_shader* shader);
+    /*!
+     * \brief @todo document
+     */
+    ShaderPresetPtr LoadShaderPreset(const std::string &path);
 
     /**
      * GetLibraryBasePath:
      * @brief Returns the full/absolute path of the dynamic library file.
      *
-     **/
+     */
     const char* GetLibraryBasePath(void);
 
   private:

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -47,88 +47,82 @@ namespace SHADERPRESET
      */
     void DestroyAddon();
 
-  /// ======== config_file_ ========
+    /// ======== config_file_ ========
 
-  /* Loads a config file. Returns NULL if file doesn't exist.
-   * NULL path will create an empty config file. */
-  config_file* ConfigFileNew(const char *path);
+    /* Loads a config file. Returns NULL if file doesn't exist.
+     * NULL path will create an empty config file. */
+    config_file* ConfigFileNew(const char *path);
 
-  /* Load a config file from a string. */
-  config_file* ConfigFileNewFromString(const char *from_string);
+    /* Load a config file from a string. */
+    config_file* ConfigFileNewFromString(const char *from_string);
 
-  /* Frees config file. */
-  void ConfigFileFree(config_file *conf);
+    /* Frees config file. */
+    void ConfigFileFree(config_file *conf);
 
-
-  /// ==== video_shader_PARSE =====
-
-  /**
-   * ShaderPresetRead:
-   * @conf              : Preset file to read from.
-   * @shader            : Shader passes handle.
-   *
-   * Loads preset file and all associated state (passes,
-   * textures, imports, etc).
-   *
-   * Returns: true (1) if successful, otherwise false (0).
-   **/
-  bool ShaderPresetRead(config_file* conf,
-                        video_shader* shader);
-
-  /**
-   * ShaderPresetWrite:
-   * @conf              : Preset file to read from.
-   * @shader            : Shader passes handle.
-   *
-   * Saves preset and all associated state (passes,
-   * textures, imports, etc) to disk.
-   **/
-  void ShaderPresetWrite(config_file *conf,
-    struct video_shader *shader);
-
-  /**
-   * ShaderPresetResolveRelative:
-   * @shader            : Shader pass handle.
-   * @ref_path          : Relative shader path.
-   *
-   * Resolves relative shader path (@ref_path) into absolute
-   * shader paths.
-   **/
-  void ShaderPresetResolveRelative(struct video_shader *shader,
-    const char *ref_path);
-
-  /**
-   * ShaderPresetResolveCurrentParameters:
-   * @conf              : Preset file to read from.
-   * @shader            : Shader passes handle.
-   *
-   * Reads the current value for all parameters from config file.
-   *
-   * Returns: true (1) if successful, otherwise false (0).
-   **/
-  bool ShaderPresetResolveCurrentParameters(config_file *conf,
-    struct video_shader *shader);
-
-  /**
-   * ShaderPresetResolveParameters:
-   * @conf              : Preset file to read from.
-   * @shader            : Shader passes handle.
-   *
-   * Resolves all shader parameters belonging to shaders.
-   *
-   * Returns: true (1) if successful, otherwise false (0).
-   **/
-  bool ShaderPresetResolveParameters(config_file *conf,
-    struct video_shader *shader);
-
-  void VideoShaderFree(video_shader* shader);
+    /// ==== video_shader_PARSE =====
 
     /**
-  * GetLibraryBasePath:
-  * @brief Returns the full/absolute path of the dynamic library file.
-  *
-  **/
-  const char* GetLibraryBasePath(void);
+     * ShaderPresetRead:
+     * @conf              : Preset file to read from.
+     * @shader            : Shader passes handle.
+     *
+     * Loads preset file and all associated state (passes,
+     * textures, imports, etc).
+     *
+     * Returns: true (1) if successful, otherwise false (0).
+     **/
+    bool ShaderPresetRead(config_file* conf, video_shader* shader);
+
+    /**
+     * ShaderPresetWrite:
+     * @conf              : Preset file to read from.
+     * @shader            : Shader passes handle.
+     *
+     * Saves preset and all associated state (passes,
+     * textures, imports, etc) to disk.
+     **/
+    void ShaderPresetWrite(config_file *conf, struct video_shader *shader);
+
+    /**
+     * ShaderPresetResolveRelative:
+     * @shader            : Shader pass handle.
+     * @ref_path          : Relative shader path.
+     *
+     * Resolves relative shader path (@ref_path) into absolute
+     * shader paths.
+     **/
+    void ShaderPresetResolveRelative(struct video_shader *shader, const char *ref_path);
+
+    /**
+     * ShaderPresetResolveCurrentParameters:
+     * @conf              : Preset file to read from.
+     * @shader            : Shader passes handle.
+     *
+     * Reads the current value for all parameters from config file.
+     *
+     * Returns: true (1) if successful, otherwise false (0).
+     **/
+    bool ShaderPresetResolveCurrentParameters(config_file *conf, struct video_shader *shader);
+
+    /**
+     * ShaderPresetResolveParameters:
+     * @conf              : Preset file to read from.
+     * @shader            : Shader passes handle.
+     *
+     * Resolves all shader parameters belonging to shaders.
+     *
+     * Returns: true (1) if successful, otherwise false (0).
+     **/
+    bool ShaderPresetResolveParameters(config_file *conf, struct video_shader *shader);
+
+    void VideoShaderFree(video_shader* shader);
+
+    /**
+     * GetLibraryBasePath:
+     * @brief Returns the full/absolute path of the dynamic library file.
+     *
+     **/
+    const char* GetLibraryBasePath(void);
 
   private:
     /*!

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -51,16 +51,16 @@ namespace SHADERPRESET
 
   /* Loads a config file. Returns NULL if file doesn't exist.
    * NULL path will create an empty config file. */
-  config_file_t_* ConfigFileNew(const char *path);
+  config_file* ConfigFileNew(const char *path);
 
   /* Load a config file from a string. */
-  config_file_t_* ConfigFileNewFromString(const char *from_string);
+  config_file* ConfigFileNewFromString(const char *from_string);
 
   /* Frees config file. */
-  void ConfigFileFree(config_file_t_ *conf);
+  void ConfigFileFree(config_file *conf);
 
 
-  /// ==== video_shader__PARSE =====
+  /// ==== video_shader_PARSE =====
 
   /**
    * ShaderPresetRead:
@@ -72,8 +72,8 @@ namespace SHADERPRESET
    *
    * Returns: true (1) if successful, otherwise false (0).
    **/
-  bool ShaderPresetRead(config_file_t_* conf,
-                        video_shader_* shader);
+  bool ShaderPresetRead(config_file* conf,
+                        video_shader* shader);
 
   /**
    * ShaderPresetWrite:
@@ -83,8 +83,8 @@ namespace SHADERPRESET
    * Saves preset and all associated state (passes,
    * textures, imports, etc) to disk.
    **/
-  void ShaderPresetWrite(config_file_t_ *conf,
-    struct video_shader_ *shader);
+  void ShaderPresetWrite(config_file *conf,
+    struct video_shader *shader);
 
   /**
    * ShaderPresetResolveRelative:
@@ -94,7 +94,7 @@ namespace SHADERPRESET
    * Resolves relative shader path (@ref_path) into absolute
    * shader paths.
    **/
-  void ShaderPresetResolveRelative(struct video_shader_ *shader,
+  void ShaderPresetResolveRelative(struct video_shader *shader,
     const char *ref_path);
 
   /**
@@ -106,8 +106,8 @@ namespace SHADERPRESET
    *
    * Returns: true (1) if successful, otherwise false (0).
    **/
-  bool ShaderPresetResolveCurrentParameters(config_file_t_ *conf,
-    struct video_shader_ *shader);
+  bool ShaderPresetResolveCurrentParameters(config_file *conf,
+    struct video_shader *shader);
 
   /**
    * ShaderPresetResolveParameters:
@@ -118,9 +118,10 @@ namespace SHADERPRESET
    *
    * Returns: true (1) if successful, otherwise false (0).
    **/
-  bool ShaderPresetResolveParameters(config_file_t_ *conf,
-    struct video_shader_ *shader);
-    void VideoShaderFree(video_shader_* shader);
+  bool ShaderPresetResolveParameters(config_file *conf,
+    struct video_shader *shader);
+
+  void VideoShaderFree(video_shader* shader);
 
     /**
   * GetLibraryBasePath:

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -71,8 +71,6 @@ namespace ADDON
                              public KODI::SHADER::IVideoShaderPresetLoader
   {
   public:
-    //static AddonPtr FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
-
     CShaderPresetAddon(const BinaryAddonBasePtr& addonInfo);
     ~CShaderPresetAddon(void) override;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -71,7 +71,7 @@ extern "C"
      * \brief Use the window viewport size
      *
      * Output size of the shader pass is relative to the size of the window
-     * viewpoirt. Value is float. This value can change over time if the user
+     * viewport. Value is float. This value can change over time if the user
      * resizes his/her window!
      */
     RARCH_SCALE_ABSOLUTE,
@@ -79,7 +79,7 @@ extern "C"
     /*!
      * \brief Use a statically defined size
      *
-     * Output size is statically defiend to a certain size. Useful for hi-res
+     * Output size is statically defined to a certain size. Useful for hi-res
      * blenders or similar.
      */
     RARCH_SCALE_VIEWPORT
@@ -130,7 +130,7 @@ extern "C"
      * \brief Float framebuffer
      *
      * This parameter defines if the pass should be rendered to a 32-bit
-     * floating point buffer. The only takes effect if the pass is actaully
+     * floating point buffer. This only takes effect if the pass is actaully
      * rendered to an FBO. This is useful for shaders which have to store FBO
      * values outside the range [0, 1].
      */
@@ -252,14 +252,6 @@ extern "C"
 
     video_shader_parameter parameters[GFX_MAX_PARAMETERS];
     unsigned num_parameters;
-
-    /*!
-     * \brief Feedback pass
-     *
-     * If < 0, no feedback pass is used. Otherwise, the FBO after pass #N is
-     * passed a texture to next frame.
-     */
-    int feedback_pass;
   } video_shader;
   ///}
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -365,7 +365,7 @@ namespace kodi
        *
        * \param shader Object to free
        */
-      virtual void ShaderPresetFree(video_shader* shader) { }
+      virtual void ShaderPresetFree(video_shader &shader) { }
 
       std::string AddonPath() const
       {
@@ -452,7 +452,7 @@ namespace kodi
       inline static void ADDON_video_shader_free(const AddonInstance_ShaderPreset* addonInstance, video_shader *shader)
       {
         if (shader != nullptr)
-          addonInstance->toAddon.addonInstance->ShaderPresetFree(shader);
+          addonInstance->toAddon.addonInstance->ShaderPresetFree(*shader);
       }
 
       AddonInstance_ShaderPreset* m_instanceData;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -25,15 +25,6 @@
 
 namespace kodi { namespace addon { class CInstanceShaderPreset; } }
 
-#ifndef PATH_MAX_LENGTH
-#define PATH_MAX_LENGTH 4096
-#endif
-
-#define GFX_MAX_SHADERS 26
-#define GFX_MAX_TEXTURES 8
-#define GFX_MAX_VARIABLES 64
-#define GFX_MAX_PARAMETERS 128
-
 extern "C"
 {
   typedef struct config_file config_file;
@@ -149,8 +140,8 @@ extern "C"
 
   typedef struct video_shader_parameter
   {
-    char id[64];
-    char desc[64];
+    char *id;
+    char *desc;
     float current;
     float minimum;
     float initial;
@@ -163,7 +154,7 @@ extern "C"
     /*!
      * \brief Path to the shader pass source
      */
-    char source_path[PATH_MAX_LENGTH];
+    char *source_path;
 
     /*!
      * \brief The vertex shader source
@@ -214,12 +205,12 @@ extern "C"
     /*!
      * \brief Name of the sampler uniform, e.g. `uniform sampler2D foo`.
      */
-    char id[64];
+    char *id;
 
     /*!
      * \brief Path of the texture
      */
-    char path[PATH_MAX_LENGTH];
+    char *path;
 
     /*!
      * \brief Filtering for the texture
@@ -241,17 +232,14 @@ extern "C"
   {
     rarch_shader_type type;
 
-    bool modern; /* Only used for XML shaders */
-    char prefix[64];
+    unsigned pass_count;
+    video_shader_pass *passes;
 
-    unsigned passes;
-    video_shader_pass pass[GFX_MAX_SHADERS];
+    unsigned lut_count;
+    video_shader_lut *luts;
 
-    unsigned luts;
-    video_shader_lut lut[GFX_MAX_TEXTURES];
-
-    video_shader_parameter parameters[GFX_MAX_PARAMETERS];
-    unsigned num_parameters;
+    unsigned parameter_count;
+    video_shader_parameter *parameters;
   } video_shader;
   ///}
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -1,138 +1,136 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
 #pragma once
-/*  Copyright (C) 2017 Team Kodi
-*
-*  RetroArch - A frontend for libretro.
-*  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
-*  Copyright (C) 2011-2017 - Daniel De Matteis
-*
-*  RetroArch is free software: you can redistribute it and/or modify it under the terms
-*  of the GNU General Public License as published by the Free Software Found-
-*  ation, either version 3 of the License, or (at your option) any later version.
-*
-*  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-*  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-*  PURPOSE.  See the GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License along with RetroArch.
-*  If not, see <http://www.gnu.org/licenses/>.
-*/
 
 #include "../AddonBase.h"
 
-#include <stdbool.h>
+#include <stdint.h>
 
 namespace kodi { namespace addon { class CInstanceShaderPreset; } }
 
 extern "C"
 {
-  /// ======== config_file_ ========
-
-  struct config_entry_list_
+  /// @name config_file
+  ///{
+  typedef struct config_entry_list
   {
-    /* If we got this from an #include,
-    * do not allow overwrite. */
-    bool readonly;
+    bool readonly; /* If we got this from an #include, do not allow overwrite */
     char *key;
     char *value;
     uint32_t key_hash;
 
-    struct config_entry_list_ *next;
-  };
+    struct config_entry_list *next;
+  } config_entry_list;
 
-  struct config_include_list_
+  typedef struct config_include_list
   {
     char *path;
-    struct config_include_list_ *next;
-  };
+    config_include_list *next;
+  } config_include_list;
 
-  struct config_file_
+  typedef struct config_file
   {
     char *path;
-    struct config_entry_list_ *entries;
-    struct config_entry_list_ *tail;
+    config_entry_list *entries;
+    config_entry_list *tail;
     unsigned include_depth;
 
-    struct config_include_list_ *includes;
-  };
+    config_include_list *includes;
+  } config_file ;
+  ///}
 
-  typedef struct config_file_ config_file_t_;
-
-  /// =============================
-
-
-  /// ==== video_shader_PARSE =====
+  /// @name video_shader_PARSE
+  ///{
 
 #ifndef PATH_MAX_LENGTH
-#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(GEKKO)|| defined(WIIU)
-#define PATH_MAX_LENGTH 512
-#else
 #define PATH_MAX_LENGTH 4096
 #endif
-#endif
 
-#ifndef GFX_MAX_SHADERS
 #define GFX_MAX_SHADERS 26
-#endif
-
-#ifndef GFX_MAX_TEXTURES
 #define GFX_MAX_TEXTURES 8
-#endif
-
-#ifndef GFX_MAX_VARIABLES
 #define GFX_MAX_VARIABLES 64
-#endif
-
-#ifndef GFX_MAX_PARAMETERS
 #define GFX_MAX_PARAMETERS 128
-#endif
 
-  struct state_tracker_uniform_info_
+  typedef enum state_tracker_type
+  {
+    RARCH_STATE_CAPTURE = 0,
+    RARCH_STATE_CAPTURE_PREV,
+    RARCH_STATE_TRANSITION,
+    RARCH_STATE_TRANSITION_COUNT,
+    RARCH_STATE_TRANSITION_PREV,
+    RARCH_STATE_PYTHON
+  } state_tracker_type;
+
+  typedef enum state_ram_type
+  {
+    RARCH_STATE_NONE,
+    RARCH_STATE_WRAM,
+    RARCH_STATE_INPUT_SLOT1,
+    RARCH_STATE_INPUT_SLOT2
+  } state_ram_type;
+
+  typedef struct state_tracker_uniform_info
   {
     char id[64];
     uint32_t addr;
-    enum state_tracker_type_ type;
-    enum state_ram_type_ ram_type;
+    state_tracker_type type;
+    state_ram_type ram_type;
     uint16_t mask;
     uint16_t equal;
-  };
+  } state_tracker_uniform_info;
 
-  enum rarch_shader_type_
+  typedef enum rarch_shader_type
   {
-    RARCH_SHADER_NONE_ = 0,
-    RARCH_SHADER_CG_,
-    RARCH_SHADER_HLSL_,
-    RARCH_SHADER_GLSL_,
-    RARCH_SHADER_SLANG_
-  };
+    RARCH_SHADER_NONE = 0,
+    RARCH_SHADER_CG,
+    RARCH_SHADER_HLSL,
+    RARCH_SHADER_GLSL,
+    RARCH_SHADER_SLANG
+  } rarch_shader_type;
 
-  enum gfx_scale_type_
+  typedef enum gfx_scale_type
   {
-    RARCH_SCALE_INPUT_ = 0,
-    RARCH_SCALE_ABSOLUTE_,
-    RARCH_SCALE_VIEWPORT_
-  };
+    RARCH_SCALE_INPUT = 0,
+    RARCH_SCALE_ABSOLUTE,
+    RARCH_SCALE_VIEWPORT
+  } gfx_scale_type;
 
-  enum
+  typedef enum filter_type
   {
-    RARCH_FILTER_UNSPEC_ = 0,
-    RARCH_FILTER_LINEAR_,
-    RARCH_FILTER_NEAREST_
-  };
+    RARCH_FILTER_UNSPEC = 0,
+    RARCH_FILTER_LINEAR,
+    RARCH_FILTER_NEAREST
+  } filter_type;
 
-  enum gfx_wrap_type_
+  typedef enum gfx_wrap_type
   {
-    RARCH_WRAP_BORDER_ = 0, /* Kinda deprecated, but keep as default.
-                            Will be translated to EDGE in GLES. */
-    RARCH_WRAP_DEFAULT_ = RARCH_WRAP_BORDER_,
-    RARCH_WRAP_EDGE_,
-    RARCH_WRAP_REPEAT_,
-    RARCH_WRAP_MIRRORED_REPEAT_
-  };
+    RARCH_WRAP_BORDER = 0, /* Deprecated, will be translated to EDGE in GLES */
+    RARCH_WRAP_EDGE,
+    RARCH_WRAP_REPEAT,
+    RARCH_WRAP_MIRRORED_REPEAT
+  } gfx_wrap_type;
 
-  struct gfx_fbo_scale_
+  typedef struct gfx_fbo_scale
   {
-    enum gfx_scale_type_ type_x;
-    enum gfx_scale_type_ type_y;
+    gfx_scale_type type_x;
+    gfx_scale_type type_y;
     float scale_x;
     float scale_y;
     unsigned abs_x;
@@ -140,9 +138,9 @@ extern "C"
     bool fp_fbo;
     bool srgb_fbo;
     bool valid;
-  };
+  } gfx_fbo_scale;
 
-  struct video_shader_parameter_
+  typedef struct video_shader_parameter
   {
     char id[64];
     char desc[64];
@@ -151,71 +149,72 @@ extern "C"
     float initial;
     float maximum;
     float step;
-  };
+  } video_shader_parameter;
 
-  struct video_shader_pass_
+  typedef struct video_shader_pass
   {
     struct
     {
       char path[PATH_MAX_LENGTH];
       struct
       {
-        char *vertex; /* Dynamically allocated. Must be free'd. */
-        char *fragment; /* Dynamically allocated. Must be free'd. */
+        char *vertex;
+        char *fragment;
       } string;
     } source;
 
     char alias[64];
-    struct gfx_fbo_scale_ fbo;
+    gfx_fbo_scale fbo;
     unsigned filter;
-    enum gfx_wrap_type_ wrap;
+    gfx_wrap_type wrap;
     unsigned frame_count_mod;
     bool mipmap;
-  };
+  } video_shader_pass;
 
-  struct video_shader_lut_
+  typedef struct video_shader_lut
   {
     char id[64];
     char path[PATH_MAX_LENGTH];
     unsigned filter;
-    enum gfx_wrap_type_ wrap;
+    gfx_wrap_type wrap;
     bool mipmap;
-  };
+  } video_shader_lut;
 
-  /* This is pretty big, shouldn't be put on the stack.
-  * Avoid lots of allocation for convenience. */
-  struct video_shader_
+  typedef struct video_shader
   {
-    enum rarch_shader_type_ type;
+    rarch_shader_type type;
 
-    bool modern; /* Only used for XML shaders. */
+    bool modern; /* Only used for XML shaders */
     char prefix[64];
 
     unsigned passes;
-    struct video_shader_pass_ pass[GFX_MAX_SHADERS];
+    video_shader_pass pass[GFX_MAX_SHADERS];
 
     unsigned luts;
-    struct video_shader_lut_ lut[GFX_MAX_TEXTURES];
+    video_shader_lut lut[GFX_MAX_TEXTURES];
 
-    struct video_shader_parameter_ parameters[GFX_MAX_PARAMETERS];
+    video_shader_parameter parameters[GFX_MAX_PARAMETERS];
     unsigned num_parameters;
 
     unsigned variables;
-    struct state_tracker_uniform_info_ variable[GFX_MAX_VARIABLES];
+    state_tracker_uniform_info variable[GFX_MAX_VARIABLES];
     char script_path[PATH_MAX_LENGTH];
-    char *script; /* Dynamically allocated. Must be free'd. Only used by XML. */
+    char *script;
     char script_class[512];
 
-    /* If < 0, no feedback pass is used. Otherwise,
-    * the FBO after pass #N is passed a texture to next frame. */
+    /*
+     * If < 0, no feedback pass is used. Otherwise, the FBO after pass #N is
+     * passed a texture to next frame.
+     */
     int feedback_pass;
-  };
+  } video_shader;
+  ///}
 
   typedef struct AddonProps_ShaderPreset
   {
     const char* user_path;              /*!< @brief path to the user profile */
     const char* addon_path;             /*!< @brief path to this add-on */
-  } ATTRIBUTE_PACKED AddonProps_ShaderPreset;
+  } AddonProps_ShaderPreset;
 
   struct AddonInstance_ShaderPreset;
 
@@ -228,50 +227,22 @@ extern "C"
   {
     kodi::addon::CInstanceShaderPreset* addonInstance;
 
-    /// ======== config_file_ ========
+    /// @name config_file
+    ///{
+    config_file* (__cdecl* config_file_new)(const AddonInstance_ShaderPreset* addonInstance, const char *path, const char *basePath);
+    config_file* (__cdecl* config_file_new_from_string)(const AddonInstance_ShaderPreset* addonInstance, const char *from_string);
+    void (__cdecl* config_file_free)(const AddonInstance_ShaderPreset* addonInstance, config_file *conf);
+    ///}
 
-    /* Loads a config file. Returns NULL if file doesn't exist.
-    * NULL path will create an empty config file. */
-    config_file_t_* (_cdecl* config_file_new)(const AddonInstance_ShaderPreset* addonInstance,
-      const char *path, const char *basePath);
-
-    /* Load a config file from a string. */
-    config_file_t_* (_cdecl* config_file_new_from_string)(const AddonInstance_ShaderPreset* addonInstance,
-      const char *from_string);
-
-    /* Frees config file. */
-    void(_cdecl* config_file_free)(const AddonInstance_ShaderPreset* addonInstance,
-      config_file_t_ *conf);
-
-    /// =============================
-
-
-    /// ==== video_shader_PARSE =====
-
-    bool(_cdecl* video_shader_read_conf_cgp)(const AddonInstance_ShaderPreset* addonInstance,
-      config_file_t_ *conf, struct video_shader_ *shader);
-
-    void(_cdecl* video_shader_write_conf_cgp)(const AddonInstance_ShaderPreset* addonInstance,
-      config_file_t_ *conf, struct video_shader_ *shader);
-
-    void(_cdecl* video_shader_resolve_relative)(const AddonInstance_ShaderPreset* addonInstance,
-      struct video_shader_ *shader, const char *ref_path);
-
-    bool(_cdecl* video_shader_resolve_current_parameters)(const AddonInstance_ShaderPreset* addonInstance,
-      config_file_t_ *conf, struct video_shader_ *shader);
-
-    bool(_cdecl* video_shader_resolve_parameters)(const AddonInstance_ShaderPreset* addonInstance,
-      config_file_t_ *conf, struct video_shader_ *shader);
-
-    enum rarch_shader_type_(_cdecl* video_shader_parse_type)(const AddonInstance_ShaderPreset* addonInstance,
-      const char *path, enum rarch_shader_type_ fallback);
-
-    /* Frees video shader. */
-    void(_cdecl* video_shader_free)(const AddonInstance_ShaderPreset* addonInstance,
-      video_shader_ *shader);
-
-    /// =============================
-
+    /// @name video_shader_PARSE
+    ///{
+    bool (__cdecl* video_shader_read_conf_cgp)(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader);
+    void (__cdecl* video_shader_write_conf_cgp)(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader);
+    void (__cdecl* video_shader_resolve_relative)(const AddonInstance_ShaderPreset* addonInstance, video_shader *shader, const char *ref_path);
+    bool (__cdecl* video_shader_resolve_current_parameters)(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader);
+    bool (__cdecl* video_shader_resolve_parameters)(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader);
+    void (__cdecl* video_shader_free)(const AddonInstance_ShaderPreset* addonInstance, video_shader *shader);
+    ///}
   } KodiToAddonFuncTable_ShaderPreset;
 
   typedef struct AddonInstance_ShaderPreset
@@ -312,104 +283,92 @@ namespace kodi
 
       ~CInstanceShaderPreset() override { }
 
-      /// ======== config_file_ ========
+      /*!
+       * \brief Loads a config file
+       *
+       * \param path The path to the config file
+       *
+       * \return The config file, or NULL if file doesn't exist
+       */
+      virtual config_file* ConfigFileNew(const char *path, const char *basePath) { return nullptr; }
 
-      /* Loads a config file. Returns NULL if file doesn't exist.
-      * NULL path will create an empty config file. */
-      virtual config_file_t_* ConfigFileNew(const char *path, const char *basePath) { return reinterpret_cast<config_file_t_*>(0x1234); }
+      /*!
+       * \brief Load a config file from a string
+       */
+      virtual config_file* ConfigFileNewFromString(const char *from_string) { return nullptr; }
 
-      /* Load a config file from a string. */
-      virtual config_file_t_* ConfigFileNewFromString(const char *from_string) { return nullptr; }
+      /*!
+       * \brief Free a config file
+       */
+      virtual void ConfigFileFree(config_file *conf) { }
 
-      /* Frees config file. */
-      virtual void ConfigFileFree(config_file_t_ *conf) { }
+      /*!
+       * \brief Loads preset file and all associated state (passes, textures,
+       * imports, etc)
+       *
+       * \param conf              Preset file to read from
+       * \param shader            Shader passes handle
+       *
+       * \return True if successful, otherwise false
+       **/
+      virtual bool ShaderPresetRead(config_file *conf, video_shader &shader) { return false; }
 
+      /*!
+       * \brief Save preset and all associated state (passes, textures, imports,
+       * etc) to disk
+       *
+       * \param conf              Preset file to read from
+       * \param shader            Shader passes handle
+       */
+      virtual void ShaderPresetWrite(config_file *conf, const video_shader &shader) { }
 
-      /// ==== video_shader_PARSE =====
+      /*!
+       * \brief Resolve relative shader path (@ref_path) into absolute shader path
+       *
+       * \param shader            Shader pass handle
+       * \param ref_path          Relative shader path
+       */
+      virtual void ShaderPresetResolveRelative(video_shader &shader, const char *ref_path) { }
 
-      /**
-      * ShaderPresetRead:
-      * @conf              : Preset file to read from.
-      * @shader            : Shader passes handle.
-      * @addonPath         : Add-on's path, so that shader source is loaded.
-      *                      If nullptr or empty, shader source isn't loaded.
-      *
-      * Loads preset file and all associated state (passes,
-      * textures, imports, etc).
-      *
-      * Returns: true (1) if successful, otherwise false (0).
-      **/
-      virtual bool ShaderPresetRead(config_file_t_ *conf,
-        struct video_shader_ *shader) {
-        return false;
-      }
+      /*!
+       * \brief Read the current value for all parameters from config file
+       *
+       * \param conf              Preset file to read from
+       * \param shader            Shader passes handle
+       *
+       * \return True if successful, otherwise false
+       */
+      virtual bool ShaderPresetResolveCurrentParameters(config_file *conf, video_shader &shader) { return false; }
 
-      /**
-      * ShaderPresetWrite:
-      * @conf              : Preset file to read from.
-      * @shader            : Shader passes handle.
-      *
-      * Saves preset and all associated state (passes,
-      * textures, imports, etc) to disk.
-      **/
-      virtual void ShaderPresetWrite(config_file_t_ *conf,
-        struct video_shader_ *shader) { }
+      /*!
+       * \brief Resolve all shader parameters belonging to the shader preset
+       *
+       * \param conf              Preset file to read from
+       * \param shader            Shader passes handle
+       *
+       * \return True if successful, otherwise false
+       */
+      virtual bool ShaderPresetResolveParameters(config_file *conf, video_shader &shader) { return false; }
 
-      /**
-      * ShaderPresetResolveRelative:
-      * @shader            : Shader pass handle.
-      * @ref_path          : Relative shader path.
-      *
-      * Resolves relative shader path (@ref_path) into absolute
-      * shader paths.
-      **/
-      virtual void ShaderPresetResolveRelative(struct video_shader_ *shader,
-        const char *ref_path) { }
+      /*!
+       * \brief Free all state related to shader preset
+       *
+       * \param shader Object to free
+       */
+      virtual void ShaderPresetFree(video_shader* shader) { }
 
-      /**
-      * ShaderPresetResolveCurrentParameters:
-      * @conf              : Preset file to read from.
-      * @shader            : Shader passes handle.
-      *
-      * Reads the current value for all parameters from config file.
-      *
-      * Returns: true (1) if successful, otherwise false (0).
-      **/
-      virtual bool ShaderPresetResolveCurrentParameters(config_file_t_ *conf,
-        struct video_shader_ *shader) {
-        return false;
-      }
-
-      /**
-      * ShaderPresetResolveParameters:
-      * @conf              : Preset file to read from.
-      * @shader            : Shader passes handle.
-      *
-      * Resolves all shader parameters belonging to shaders.
-      *
-      * Returns: true (1) if successful, otherwise false (0).
-      **/
-      virtual bool ShaderPresetResolveParameters(config_file_t_ *conf,
-        struct video_shader_ *shader) {
-        return false;
-      }
-
-      /**
-      * FreePresetFile
-      * \shader shader Object to free.
-      *
-      * Frees all state related to shader
-      */
-      virtual void ShaderPresetFree(video_shader_* shader) = 0;
-
-      const std::string AddonPath() const
+      std::string AddonPath() const
       {
-        return m_instanceData->props.addon_path;
+        if (m_instanceData->props.addon_path)
+          return m_instanceData->props.addon_path;
+        return "";
       }
 
-      const std::string UserPath() const
+      std::string UserPath() const
       {
-        return m_instanceData->props.user_path;
+        if (m_instanceData->props.user_path)
+          return m_instanceData->props.user_path;
+        return "";
       }
 
     private:
@@ -433,51 +392,61 @@ namespace kodi
         m_instanceData->toAddon.video_shader_free = ADDON_video_shader_free;
       }
 
-      inline static config_file_t_* ADDON_config_file_new(const AddonInstance_ShaderPreset* addonInstance,
-        const char *path, const char *basePath)
+      inline static config_file* ADDON_config_file_new(const AddonInstance_ShaderPreset* addonInstance, const char *path, const char *basePath)
       {
         return addonInstance->toAddon.addonInstance->ConfigFileNew(path, basePath);
       }
-      inline static config_file_t_* ADDON_config_file_new_from_string(const AddonInstance_ShaderPreset* addonInstance,
-        const char *from_string)
+
+      inline static config_file* ADDON_config_file_new_from_string(const AddonInstance_ShaderPreset* addonInstance, const char *from_string)
       {
         return addonInstance->toAddon.addonInstance->ConfigFileNewFromString(from_string);
       }
-      inline static void ADDON_config_file_free(const AddonInstance_ShaderPreset* addonInstance,
-        config_file_t_ *conf)
+
+      inline static void ADDON_config_file_free(const AddonInstance_ShaderPreset* addonInstance, config_file *conf)
       {
         return addonInstance->toAddon.addonInstance->ConfigFileFree(conf);
       }
 
-      inline static bool ADDON_video_shader_read_conf_cgp(const AddonInstance_ShaderPreset* addonInstance,
-        config_file_t_ *conf, struct video_shader_ *shader)
+      inline static bool ADDON_video_shader_read_conf_cgp(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetRead(conf, shader);
+        if (shader != nullptr)
+          return addonInstance->toAddon.addonInstance->ShaderPresetRead(conf, *shader);
+
+        return false;
       }
-      inline static void ADDON_video_shader_write_conf_cgp(const AddonInstance_ShaderPreset* addonInstance,
-        config_file_t_ *conf, struct video_shader_ *shader)
+
+      inline static void ADDON_video_shader_write_conf_cgp(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, const video_shader *shader)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetWrite(conf, shader);
+        if (shader != nullptr)
+          addonInstance->toAddon.addonInstance->ShaderPresetWrite(conf, *shader);
       }
-      inline static void ADDON_video_shader_resolve_relative(const AddonInstance_ShaderPreset* addonInstance,
-        struct video_shader_ *shader, const char *ref_path)
+
+      inline static void ADDON_video_shader_resolve_relative(const AddonInstance_ShaderPreset* addonInstance, video_shader *shader, const char *ref_path)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetResolveRelative(shader, ref_path);
+        if (shader != nullptr)
+          addonInstance->toAddon.addonInstance->ShaderPresetResolveRelative(*shader, ref_path);
       }
-      inline static bool ADDON_video_shader_resolve_current_parameters(const AddonInstance_ShaderPreset* addonInstance,
-        config_file_t_ *conf, struct video_shader_ *shader)
+
+      inline static bool ADDON_video_shader_resolve_current_parameters(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetResolveCurrentParameters(conf, shader);
+        if (shader != nullptr)
+          return addonInstance->toAddon.addonInstance->ShaderPresetResolveCurrentParameters(conf, *shader);
+
+        return false;
       }
-      inline static bool ADDON_video_shader_resolve_parameters(const AddonInstance_ShaderPreset* addonInstance,
-        config_file_t_ *conf, struct video_shader_ *shader)
+
+      inline static bool ADDON_video_shader_resolve_parameters(const AddonInstance_ShaderPreset* addonInstance, config_file *conf, video_shader *shader)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetResolveParameters(conf, shader);
+        if (shader != nullptr)
+          return addonInstance->toAddon.addonInstance->ShaderPresetResolveParameters(conf, *shader);
+        
+        return false;
       }
-      inline static void ADDON_video_shader_free(const AddonInstance_ShaderPreset* addonInstance,
-        video_shader_ *conf)
+
+      inline static void ADDON_video_shader_free(const AddonInstance_ShaderPreset* addonInstance, video_shader *shader)
       {
-        return addonInstance->toAddon.addonInstance->ShaderPresetFree(conf);
+        if (shader != nullptr)
+          addonInstance->toAddon.addonInstance->ShaderPresetFree(shader);
       }
 
       AddonInstance_ShaderPreset* m_instanceData;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -29,15 +29,6 @@ extern "C"
 {
   typedef struct config_file config_file;
 
-  typedef enum rarch_shader_type
-  {
-    RARCH_SHADER_NONE = 0,
-    RARCH_SHADER_CG,
-    RARCH_SHADER_HLSL,
-    RARCH_SHADER_GLSL,
-    RARCH_SHADER_SLANG
-  } rarch_shader_type;
-
   /*!
    * \brief Scale types
    *
@@ -48,7 +39,7 @@ extern "C"
    * output at the full resolution rather than assuming of scale of 1.0, and
    * bypasses any frame-buffer object rendering.
    */
-  typedef enum gfx_scale_type
+  typedef enum SHADER_SCALE_TYPE
   {
     /*!
      * \brief Use the source size
@@ -56,7 +47,7 @@ extern "C"
      * Output size of the shader pass is relative to the input size. Value is
      * float.
      */
-    RARCH_SCALE_INPUT = 0,
+    SHADER_SCALE_TYPE_INPUT,
 
     /*!
      * \brief Use the window viewport size
@@ -65,7 +56,7 @@ extern "C"
      * viewport. Value is float. This value can change over time if the user
      * resizes his/her window!
      */
-    RARCH_SCALE_ABSOLUTE,
+    SHADER_SCALE_TYPE_ABSOLUTE,
 
     /*!
      * \brief Use a statically defined size
@@ -73,44 +64,44 @@ extern "C"
      * Output size is statically defined to a certain size. Useful for hi-res
      * blenders or similar.
      */
-    RARCH_SCALE_VIEWPORT
-  } gfx_scale_type;
+    SHADER_SCALE_TYPE_VIEWPORT
+  } SHADER_SCALE_TYPE;
 
-  typedef enum filter_type
+  typedef enum SHADER_FILTER_TYPE
   {
-    RARCH_FILTER_UNSPEC = 0,
-    RARCH_FILTER_LINEAR,
-    RARCH_FILTER_NEAREST
-  } filter_type;
+    SHADER_FILTER_TYPE_UNSPEC,
+    SHADER_FILTER_TYPE_LINEAR,
+    SHADER_FILTER_TYPE_NEAREST
+  } SHADER_FILTER_TYPE;
 
   /*!
    * \brief Texture wrapping mode
    */
-  typedef enum gfx_wrap_type
+  typedef enum SHADER_WRAP_TYPE
   {
-    RARCH_WRAP_BORDER = 0, /* Deprecated, will be translated to EDGE in GLES */
-    RARCH_WRAP_EDGE,
-    RARCH_WRAP_REPEAT,
-    RARCH_WRAP_MIRRORED_REPEAT
-  } gfx_wrap_type;
+    SHADER_WRAP_TYPE_BORDER, /* Deprecated, will be translated to EDGE in GLES */
+    SHADER_WRAP_TYPE_EDGE,
+    SHADER_WRAP_TYPE_REPEAT,
+    SHADER_WRAP_TYPE_MIRRORED_REPEAT
+  } SHADER_WRAP_TYPE;
 
   /*!
    * \brief FBO scaling parameters for a single axis
    */
-  typedef struct gfx_fbo_scale_axis
+  typedef struct fbo_scale_axis
   {
-    gfx_scale_type type;
+    SHADER_SCALE_TYPE type;
     union
     {
       float scale;
       unsigned abs;
     };
-  } gfx_fbo_scale_axis;
+  } fbo_scale_axis;
 
   /*!
    * \brief FBO parameters
    */
-  typedef struct gfx_fbo_scale
+  typedef struct fbo_scale
   {
     /*!
      * \brief sRGB framebuffer
@@ -130,13 +121,13 @@ extern "C"
     /*!
      * \brief Scaling parameters for X axis
      */
-    gfx_fbo_scale_axis scale_x;
+    fbo_scale_axis scale_x;
 
     /*!
      * \brief Scaling parameters for Y axis
      */
-    gfx_fbo_scale_axis scale_y;
-  } gfx_fbo_scale;
+    fbo_scale_axis scale_y;
+  } fbo_scale;
 
   typedef struct video_shader_parameter
   {
@@ -175,19 +166,19 @@ extern "C"
     /*!
      * \brief FBO parameters
      */
-    gfx_fbo_scale fbo;
+    fbo_scale fbo;
 
     /*!
      * \brief Defines how the result of this pass will be filtered
      *
      * @todo Define behavior for unspecified filter
      */
-    filter_type filter;
+    SHADER_FILTER_TYPE filter;
 
     /*!
      * \brief Wrapping mode
      */
-    gfx_wrap_type wrap;
+    SHADER_WRAP_TYPE wrap;
 
     /*!
      * \brief Frame count mod
@@ -215,12 +206,12 @@ extern "C"
     /*!
      * \brief Filtering for the texture
      */
-    filter_type filter;
+    SHADER_FILTER_TYPE filter;
 
     /*!
      * \brief Texture wrapping mode
      */
-    gfx_wrap_type wrap;
+    SHADER_WRAP_TYPE wrap;
 
     /*!
      * \brief Use mipmapping for the texture
@@ -230,8 +221,6 @@ extern "C"
 
   typedef struct video_shader
   {
-    rarch_shader_type type;
-
     unsigned pass_count;
     video_shader_pass *passes;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -159,11 +159,6 @@ extern "C"
     char *fragment_source;
 
     /*!
-     * \brief Alias
-     */
-    char alias[64];
-
-    /*!
      * \brief FBO parameters
      */
     fbo_scale fbo;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -142,8 +142,8 @@
                                                       "StreamCodec.h" \
                                                       "StreamCrypto.h"
 
-#define ADDON_INSTANCE_VERSION_SHADERPRESET           "0.0.2"
-#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "0.0.2"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET           "0.0.3"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "0.0.3"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_XML_ID    "kodi.binary.instance.shaderpreset"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_DEPENDS   "addon-instance/ShaderPreset.h"
 

--- a/xbmc/cores/RetroPlayer/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/CMakeLists.txt
@@ -3,7 +3,8 @@ set(SOURCES RetroPlayer.cpp
             RetroPlayerAutoSave.cpp
             RetroPlayerInput.cpp
             RetroPlayerVideo.cpp
-            VideoShaderPreset.cpp)
+            VideoShaderPreset.cpp
+)
 
 set(HEADERS IVideoShaderPreset.h
             RetroPlayer.h
@@ -12,6 +13,7 @@ set(HEADERS IVideoShaderPreset.h
             RetroPlayerDefines.h
             RetroPlayerInput.h
             RetroPlayerVideo.h
-            VideoShaderPreset.h)
+            VideoShaderPreset.h
+)
 
 core_add_library(retroplayer)

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -53,7 +53,7 @@ namespace SHADERPRESET
      * \param presetPath Full path of the preset file.
      * \return True on successful parsing, false on failed.
      */
-    virtual bool ReadPresetFile(std::string presetPath) = 0;
+    virtual bool ReadPresetFile(const std::string &presetPath) = 0;
 
     /**
     * \brief Reads a shader preset already parsed in a config_file
@@ -62,22 +62,7 @@ namespace SHADERPRESET
     * \param presetConf Configuration file of the preset file that's been parsed.
     * \return True if successfully read, false on failure.
     */
-    virtual bool ReadPresetConfig(config_file* presetConf) = 0;
-
-    /**
-    * \brief Reads/Parses a shader preset already loaded in memory as a
-    *        string and loads its state to the object. What this state
-    *        is is implementation specific.
-    * \param presetString String of the preset file.
-    * \return True on successful parsing, false on failed.
-    */
-    virtual bool ReadPresetString(std::string presetString) = 0;
-
-    /**
-    * \brief Frees all state related to shader
-    * \param shader Object to free.
-    */
-    virtual void FreePresetFile(video_shader* shader) = 0;
+    virtual bool ReadPresetConfig() = 0;
 
     /**
     * ShaderPresetResolveParameters:
@@ -88,6 +73,6 @@ namespace SHADERPRESET
     **/
     virtual bool ResolveParameters() = 0;
 
-    // virtual bool WritePresetFile(conf_file_t* presetConf) = 0;
+    // virtual bool WritePresetFile() = 0;
   };
 } // namespace SHADERPRESET

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -68,7 +68,6 @@ namespace SHADER
     std::string sourcePath;
     std::string vertexSource;
     std::string fragmentSource;
-    std::string alias;
     FILTER_TYPE filter = FILTER_TYPE_NONE;
     WRAP_TYPE wrap = WRAP_TYPE_BORDER;
     unsigned int frameCountMod = 0;

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -56,13 +56,13 @@ namespace SHADERPRESET
     virtual bool ReadPresetFile(std::string presetPath) = 0;
 
     /**
-    * \brief Reads a shader preset already parsed in a config_file_t_
+    * \brief Reads a shader preset already parsed in a config_file
     *        and loads its state to the object. What this state is
     *        is implementation specific.
     * \param presetConf Configuration file of the preset file that's been parsed.
     * \return True if successfully read, false on failure.
     */
-    virtual bool ReadPresetConfig(config_file_t_* presetConf) = 0;
+    virtual bool ReadPresetConfig(config_file* presetConf) = 0;
 
     /**
     * \brief Reads/Parses a shader preset already loaded in memory as a
@@ -77,7 +77,7 @@ namespace SHADERPRESET
     * \brief Frees all state related to shader
     * \param shader Object to free.
     */
-    virtual void FreePresetFile(video_shader_* shader) = 0;
+    virtual void FreePresetFile(video_shader* shader) = 0;
 
     /**
     * ShaderPresetResolveParameters:

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -26,13 +26,6 @@ namespace KODI
 {
 namespace SHADER
 {
-  enum SHADER_TYPE
-  {
-    SHADER_TYPE_NONE,
-    SHADER_TYPE_HLSL,
-    SHADER_TYPE_GLSL,
-  };
-
   enum FILTER_TYPE
   {
     FILTER_TYPE_NONE,
@@ -105,8 +98,6 @@ namespace SHADER
 
   struct VideoShaderPreset
   {
-    SHADER_TYPE type = SHADER_TYPE_NONE;
-
     std::vector<VideoShaderPass> passes;
     std::vector<VideoShaderLut> luts;
     std::vector<VideoShaderParameter> parameters;

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -110,9 +110,6 @@ namespace SHADER
     std::vector<VideoShaderPass> passes;
     std::vector<VideoShaderLut> luts;
     std::vector<VideoShaderParameter> parameters;
-
-    //! @todo
-    int m_feedbackPass = -1;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/IVideoShaderPreset.h
@@ -20,7 +20,102 @@
 #pragma once
 
 #include <string>
-#include "addons/ShaderPreset.h"
+#include <vector>
+
+namespace KODI
+{
+namespace SHADER
+{
+  enum SHADER_TYPE
+  {
+    SHADER_TYPE_NONE,
+    SHADER_TYPE_HLSL,
+    SHADER_TYPE_GLSL,
+  };
+
+  enum FILTER_TYPE
+  {
+    FILTER_TYPE_NONE,
+    FILTER_TYPE_LINEAR,
+    FILTER_TYPE_NEAREST
+  };
+
+  enum WRAP_TYPE
+  {
+    WRAP_TYPE_BORDER,
+    WRAP_TYPE_EDGE,
+    WRAP_TYPE_REPEAT,
+    WRAP_TYPE_MIRRORED_REPEAT,
+  };
+
+  enum SCALE_TYPE
+  {
+    SCALE_TYPE_INPUT,
+    SCALE_TYPE_ABSOLUTE,
+    SCALE_TYPE_VIEWPORT,
+  };
+
+  struct FboScaleAxis
+  {
+    SCALE_TYPE type = SCALE_TYPE_INPUT;
+    float scale = 1.0;
+    unsigned int abs = 1;
+  };
+
+  struct FboScale
+  {
+    bool sRgbFramebuffer = false;
+    bool floatFramebuffer = false;
+    FboScaleAxis scaleX;
+    FboScaleAxis scaleY;
+  };
+
+  struct VideoShaderPass
+  {
+    std::string sourcePath;
+    std::string vertexSource;
+    std::string fragmentSource;
+    std::string alias;
+    FILTER_TYPE filter = FILTER_TYPE_NONE;
+    WRAP_TYPE wrap = WRAP_TYPE_BORDER;
+    unsigned int frameCountMod = 0;
+    FboScale fbo;
+    bool mipmap = false;
+  };
+
+  struct VideoShaderLut
+  {
+    std::string strId;
+    std::string path;
+    FILTER_TYPE filter = FILTER_TYPE_NONE;
+    WRAP_TYPE wrap = WRAP_TYPE_BORDER;
+    bool mipmap = false;
+  };
+
+  struct VideoShaderParameter
+  {
+    std::string strId;
+    std::string description;
+    float current = 0.0f;
+    float minimum = 0.0f;
+    float initial = 0.0f;
+    float maximum = 0.0f;
+    float step = 0.0f;
+  };
+
+  struct VideoShaderPreset
+  {
+    SHADER_TYPE type = SHADER_TYPE_NONE;
+
+    std::vector<VideoShaderPass> passes;
+    std::vector<VideoShaderLut> luts;
+    std::vector<VideoShaderParameter> parameters;
+
+    //! @todo
+    int m_feedbackPass = -1;
+  };
+}
+}
 
 namespace SHADERPRESET
 {
@@ -32,7 +127,7 @@ namespace SHADERPRESET
   public:
     virtual ~IVideoShaderPreset() = default;
 
-    /**
+    /*!
      * \brief Perform initialization of the object
      *        Implementation may choose to perform it if the object is
      *        used without having this having been called.
@@ -40,14 +135,13 @@ namespace SHADERPRESET
      */
     virtual bool Init() = 0;
 
-    /**
+    /*!
      * \brief Perform deinitialization of the object.
      *        May be used to get rid of unneded resources.
      */
     virtual void Destroy() = 0;
 
-
-    /**
+    /*!
      * \brief Reads/Parses a shader preset file and loads its state to the
      *        object. What this state is is implementation specific.
      * \param presetPath Full path of the preset file.
@@ -55,24 +149,6 @@ namespace SHADERPRESET
      */
     virtual bool ReadPresetFile(const std::string &presetPath) = 0;
 
-    /**
-    * \brief Reads a shader preset already parsed in a config_file
-    *        and loads its state to the object. What this state is
-    *        is implementation specific.
-    * \param presetConf Configuration file of the preset file that's been parsed.
-    * \return True if successfully read, false on failure.
-    */
-    virtual bool ReadPresetConfig() = 0;
-
-    /**
-    * ShaderPresetResolveParameters:
-    *
-    * Resolves all shader parameters belonging to shaders.
-    *
-    * Returns: True if successful, otherwise false false.
-    **/
-    virtual bool ResolveParameters() = 0;
-
     // virtual bool WritePresetFile() = 0;
   };
-} // namespace SHADERPRESET
+}

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -25,6 +25,7 @@
 #include "RetroPlayerVideo.h"
 #include "addons/AddonManager.h"
 #include "cores/DataCacheCore.h"
+#include "cores/RetroPlayer/guicontrols/GUIGameControlManager.h"
 #include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
 #include "cores/RetroPlayer/rendering/RPRenderManager.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
@@ -467,20 +468,21 @@ void CRetroPlayer::FrameMove()
 
 void CRetroPlayer::Render(bool clear, uint32_t alpha /* = 255 */, bool gui /* = true */)
 {
-  RETRO::CGUIRenderSettings &renderSettings = CServiceBroker::GetGameServices().RenderSettings();
+  CGUIGameControlManager &gameControls = CServiceBroker::GetGameServices().GameControls();
 
   ViewMode viewMode = m_renderManager->GetRenderViewMode();
   ESCALINGMETHOD scalingMedthod = m_renderManager->GetScalingMethod();
 
-  if (renderSettings.IsGuiRenderSettingsEnabled())
+  if (gameControls.IsControlActive())
   {
+    const CGUIRenderSettings &renderSettings = gameControls.GetRenderSettings();
     m_renderManager->SetRenderViewMode(renderSettings.GetRenderViewMode());
     m_renderManager->SetScalingMethod(renderSettings.GetScalingMethod());
   }
 
   m_renderManager->Render(clear, 0, alpha, gui);
 
-  if (renderSettings.IsGuiRenderSettingsEnabled())
+  if (gameControls.IsControlActive())
   {
     m_renderManager->SetRenderViewMode(viewMode);
     m_renderManager->SetScalingMethod(scalingMedthod);

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -83,7 +83,6 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 
   //! @todo - Remove this when RetroPlayer has a renderer
   CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
-  videoSettings.m_ScalingMethod = CMediaSettings::GetInstance().GetCurrentGameSettings().ScalingMethod();
   videoSettings.m_ViewMode = CMediaSettings::GetInstance().GetCurrentGameSettings().ViewMode();
 
   CSingleLock lock(m_mutex);
@@ -470,22 +469,22 @@ void CRetroPlayer::Render(bool clear, uint32_t alpha /* = 255 */, bool gui /* = 
 {
   CGUIGameControlManager &gameControls = CServiceBroker::GetGameServices().GameControls();
 
+  const std::string &shaderPreset = m_renderManager->GetShaderPreset();
   ViewMode viewMode = m_renderManager->GetRenderViewMode();
-  ESCALINGMETHOD scalingMedthod = m_renderManager->GetScalingMethod();
 
   if (gameControls.IsControlActive())
   {
     const CGUIRenderSettings &renderSettings = gameControls.GetRenderSettings();
+    m_renderManager->SetShaderPreset(renderSettings.GetVideoFilter());
     m_renderManager->SetRenderViewMode(renderSettings.GetRenderViewMode());
-    m_renderManager->SetScalingMethod(renderSettings.GetScalingMethod());
   }
 
   m_renderManager->Render(clear, 0, alpha, gui);
 
   if (gameControls.IsControlActive())
   {
+    m_renderManager->SetShaderPreset(shaderPreset);
     m_renderManager->SetRenderViewMode(viewMode);
-    m_renderManager->SetScalingMethod(scalingMedthod);
   }
 }
 

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
@@ -90,11 +90,11 @@ bool CVideoShaderPreset::ReadPresetFile(std::string presetPath)
   return result;
 }
 
-bool CVideoShaderPreset::ReadPresetConfig(config_file_t_* conf)
+bool CVideoShaderPreset::ReadPresetConfig(config_file* conf)
 {
   if (!shaderPresetAddon) return false;
 
-  m_videoShader = static_cast<video_shader_*>(calloc(1, sizeof(video_shader_)));
+  m_videoShader = static_cast<video_shader*>(calloc(1, sizeof(video_shader)));
 
   auto readResult = shaderPresetAddon->ShaderPresetRead(conf, m_videoShader);
 
@@ -103,11 +103,11 @@ bool CVideoShaderPreset::ReadPresetConfig(config_file_t_* conf)
     // Copy over every field we want except parameters, these are resolved and copied elsewhere
     type = m_videoShader->type;
     m_Passes = m_videoShader->passes;
-    memcpy(m_Pass, m_videoShader->pass, GFX_MAX_SHADERS * sizeof video_shader_pass_);
+    memcpy(m_Pass, m_videoShader->pass, GFX_MAX_SHADERS * sizeof video_shader_pass);
     m_Luts = m_videoShader->luts;
-    memcpy(m_Lut, m_videoShader->lut, GFX_MAX_TEXTURES * sizeof video_shader_lut_);
+    memcpy(m_Lut, m_videoShader->lut, GFX_MAX_TEXTURES * sizeof video_shader_lut);
     m_Variables = m_videoShader->variables;
-    memcpy(m_Variable, m_videoShader->variable, GFX_MAX_VARIABLES * sizeof state_tracker_uniform_info_);
+    memcpy(m_Variable, m_videoShader->variable, GFX_MAX_VARIABLES * sizeof state_tracker_uniform_info);
     m_FeedbackPass = m_videoShader->feedback_pass;
 
     CLog::Log(LOGINFO, "Shader Preset Addon: Read shader preset %s", conf->path);
@@ -118,7 +118,7 @@ bool CVideoShaderPreset::ReadPresetConfig(config_file_t_* conf)
 
 bool CVideoShaderPreset::ReadPresetString(std::string presetString)
 {
-  config_file_t_* conf = shaderPresetAddon->ConfigFileNewFromString(presetString.c_str());
+  config_file* conf = shaderPresetAddon->ConfigFileNewFromString(presetString.c_str());
   bool result = ReadPresetConfig(conf);
   FreeConfigFile(conf);
   return result;
@@ -128,7 +128,7 @@ bool CVideoShaderPreset::ResolveParameters()
 {
   bool resolveResult = shaderPresetAddon->ShaderPresetResolveParameters(m_config, m_videoShader);
   m_NumParameters = m_videoShader->num_parameters;
-  memcpy(m_Parameters, m_videoShader->parameters, GFX_MAX_PARAMETERS * sizeof video_shader_parameter_);
+  memcpy(m_Parameters, m_videoShader->parameters, GFX_MAX_PARAMETERS * sizeof video_shader_parameter);
   return resolveResult;
 }
 
@@ -162,12 +162,12 @@ void CShaderPresetAddon::DestroyAddon()
   }
 }
 
-void CVideoShaderPreset::FreeConfigFile(config_file_t_* conf)
+void CVideoShaderPreset::FreeConfigFile(config_file* conf)
 {
   return shaderPresetAddon->ConfigFileFree(conf);
 }
 
-void CVideoShaderPreset::FreePresetFile(video_shader_* shader)
+void CVideoShaderPreset::FreePresetFile(video_shader* shader)
 {
   return shaderPresetAddon->VideoShaderFree(shader);
 }

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
@@ -34,15 +34,7 @@ std::unique_ptr<ADDON::CShaderPresetAddon> CVideoShaderPreset::shaderPresetAddon
 
 CVideoShaderPreset::CVideoShaderPreset()
 {
-  Init();
-}
-
-CVideoShaderPreset::CVideoShaderPreset(std::string presetPath)
-{
-  if (Init())
-  {
-    ReadPresetFile(presetPath);
-  }
+  //! @todo Initializes members in header
 }
 
 bool CVideoShaderPreset::Init()

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
@@ -21,6 +21,7 @@
 #include "VideoShaderPreset.h"
 #include "ServiceBroker.h"
 #include "addons/binary-addons/BinaryAddonBase.h"
+#include "addons/ShaderPreset.h"
 #include "utils/log.h"
 
 #include <string>
@@ -29,8 +30,7 @@
 using namespace KODI;
 using namespace SHADERPRESET;
 
-
-std::unique_ptr<CShaderPresetAddon> CVideoShaderPreset::shaderPresetAddon;
+std::unique_ptr<ADDON::CShaderPresetAddon> CVideoShaderPreset::shaderPresetAddon;
 
 CVideoShaderPreset::CVideoShaderPreset()
 {
@@ -57,7 +57,7 @@ bool CVideoShaderPreset::Init()
 
   if (!addonInfos.empty())
   {
-    shaderPresetAddon.reset(new CShaderPresetAddon(addonInfos.front()));
+    shaderPresetAddon.reset(new ADDON::CShaderPresetAddon(addonInfos.front()));
     shaderPresetAddon->CreateAddon();
     return true;
   }
@@ -135,31 +135,6 @@ bool CVideoShaderPreset::ResolveParameters()
 CVideoShaderPreset::~CVideoShaderPreset()
 {
   Destroy();
-}
-
-bool CShaderPresetAddon::CreateAddon(void)
-{
-  CExclusiveLock lock(m_dllSection);
-
-  // Reset all properties to defaults
-  ResetProperties();
-
-  // Initialise the add-on
-  CLog::Log(LOGDEBUG, "%s - creating ShaderPreset add-on instance '%s'",
-    __FUNCTION__, Name().c_str());
-
-  if (CreateInstance(&m_struct) != ADDON_STATUS_OK)
-    return false;
-
-  return true;
-}
-
-void CShaderPresetAddon::DestroyAddon()
-{
-  {
-    CExclusiveLock lock(m_dllSection);
-    DestroyInstance();
-  }
 }
 
 void CVideoShaderPreset::FreeConfigFile(config_file* conf)

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.cpp
@@ -92,8 +92,6 @@ bool CVideoShaderPreset::ReadPresetConfig()
     memcpy(m_Pass, m_videoShader->pass, GFX_MAX_SHADERS * sizeof video_shader_pass);
     m_Luts = m_videoShader->luts;
     memcpy(m_Lut, m_videoShader->lut, GFX_MAX_TEXTURES * sizeof video_shader_lut);
-    m_Variables = m_videoShader->variables;
-    memcpy(m_Variable, m_videoShader->variable, GFX_MAX_VARIABLES * sizeof state_tracker_uniform_info);
     m_FeedbackPass = m_videoShader->feedback_pass;
 
     //CLog::Log(LOGINFO, "Shader Preset Addon: Read shader preset %s", conf->path); //! @todo

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -54,9 +54,6 @@ namespace SHADERPRESET
     video_shader_parameter m_Parameters[GFX_MAX_PARAMETERS];
     unsigned m_NumParameters;
 
-    unsigned m_Variables;
-    state_tracker_uniform_info m_Variable[GFX_MAX_VARIABLES];
-
     /* If < 0, no feedback pass is used. Otherwise,
     * the FBO after pass #N is passed a texture to next frame. */
     int m_FeedbackPass;

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -38,19 +38,19 @@ namespace SHADERPRESET
   //private:
   public:
     // todo: probably don't need that
-    enum rarch_shader_type_ type;
+    rarch_shader_type type;
 
     unsigned m_Passes;
-    struct video_shader_pass_ m_Pass[GFX_MAX_SHADERS];
+    video_shader_pass m_Pass[GFX_MAX_SHADERS];
 
     unsigned m_Luts;
-    struct video_shader_lut_ m_Lut[GFX_MAX_TEXTURES];
+    video_shader_lut m_Lut[GFX_MAX_TEXTURES];
 
-    struct video_shader_parameter_ m_Parameters[GFX_MAX_PARAMETERS];
+    video_shader_parameter m_Parameters[GFX_MAX_PARAMETERS];
     unsigned m_NumParameters;
 
     unsigned m_Variables;
-    struct state_tracker_uniform_info_ m_Variable[GFX_MAX_VARIABLES];
+    state_tracker_uniform_info m_Variable[GFX_MAX_VARIABLES];
 
     /* If < 0, no feedback pass is used. Otherwise,
     * the FBO after pass #N is passed a texture to next frame. */
@@ -67,18 +67,18 @@ namespace SHADERPRESET
     void Destroy() override;
 
     bool ReadPresetFile(std::string presetPath) override;
-    bool ReadPresetConfig(config_file_t_* presetConf) override;
+    bool ReadPresetConfig(config_file* presetConf) override;
     bool ReadPresetString(std::string presetString) override;
-    void FreePresetFile(video_shader_* shader) override;
+    void FreePresetFile(video_shader* shader) override;
     bool ResolveParameters() override;
-    // bool WritePresetFile(config_file_t_* presetConf) override;  // TODO?: preset file writing
+    // bool WritePresetFile(config_file* presetConf) override;  // TODO?: preset file writing
 
     ~CVideoShaderPreset() override;
 
   protected:
-     static void FreeConfigFile(config_file_t_* conf);
+     static void FreeConfigFile(config_file* conf);
   private:
-    config_file_t_* m_config;
-    video_shader_* m_videoShader;
+    config_file* m_config;
+    video_shader* m_videoShader;
   };
 } // namespace SHADERPRESET

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -26,6 +26,7 @@
 
 namespace ADDON
 {
+  class CShaderPreset;
   class CShaderPresetAddon;
 }
 
@@ -70,19 +71,15 @@ namespace SHADERPRESET
     bool Init() override;
     void Destroy() override;
 
-    bool ReadPresetFile(std::string presetPath) override;
-    bool ReadPresetConfig(config_file* presetConf) override;
-    bool ReadPresetString(std::string presetString) override;
-    void FreePresetFile(video_shader* shader) override;
+    bool ReadPresetFile(const std::string &presetPath) override;
+    bool ReadPresetConfig() override;
     bool ResolveParameters() override;
     // bool WritePresetFile(config_file* presetConf) override;  // TODO?: preset file writing
 
     ~CVideoShaderPreset() override;
 
-  protected:
-     static void FreeConfigFile(config_file* conf);
   private:
-    config_file* m_config;
-    video_shader* m_videoShader;
+    std::shared_ptr<ADDON::CShaderPreset> m_config;
+    std::unique_ptr<video_shader> m_videoShader;
   };
 } // namespace SHADERPRESET

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -21,9 +21,13 @@
 
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "IVideoShaderPreset.h"
-#include "addons/ShaderPreset.h"
 
 #include <memory>
+
+namespace ADDON
+{
+  class CShaderPresetAddon;
+}
 
 namespace SHADERPRESET
 {
@@ -58,7 +62,7 @@ namespace SHADERPRESET
 
   public:
     // Instance of CShaderPreset
-    static std::unique_ptr<CShaderPresetAddon> shaderPresetAddon;
+    static std::unique_ptr<ADDON::CShaderPresetAddon> shaderPresetAddon;
     explicit CVideoShaderPreset();
     explicit CVideoShaderPreset(std::string presetPath);
 

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -23,6 +23,7 @@
 #include "IVideoShaderPreset.h"
 
 #include <memory>
+#include <vector>
 
 namespace ADDON
 {
@@ -32,32 +33,8 @@ namespace ADDON
 
 namespace SHADERPRESET
 {
-  /*
-   * C++ (OOP) Wrapper class to RetroArch's video_shader struct
-   *
-   * Uses CShaderPresetAddon for parsing shader preset files
-   */
-
   class CVideoShaderPreset : public IVideoShaderPreset
   {
-  //private:
-  public:
-    // todo: probably don't need that
-    rarch_shader_type type;
-
-    unsigned m_Passes;
-    video_shader_pass m_Pass[GFX_MAX_SHADERS];
-
-    unsigned m_Luts;
-    video_shader_lut m_Lut[GFX_MAX_TEXTURES];
-
-    video_shader_parameter m_Parameters[GFX_MAX_PARAMETERS];
-    unsigned m_NumParameters;
-
-    /* If < 0, no feedback pass is used. Otherwise,
-    * the FBO after pass #N is passed a texture to next frame. */
-    int m_FeedbackPass;
-
   public:
     // Instance of CShaderPreset
     static std::unique_ptr<ADDON::CShaderPresetAddon> shaderPresetAddon;
@@ -68,14 +45,13 @@ namespace SHADERPRESET
     void Destroy() override;
 
     bool ReadPresetFile(const std::string &presetPath) override;
-    bool ReadPresetConfig() override;
-    bool ResolveParameters() override;
     // bool WritePresetFile(config_file* presetConf) override;  // TODO?: preset file writing
 
     ~CVideoShaderPreset() override;
 
+    const KODI::SHADER::VideoShaderPreset &Preset() const { return m_videoShader; }
+
   private:
-    std::shared_ptr<ADDON::CShaderPreset> m_config;
-    std::unique_ptr<video_shader> m_videoShader;
+    KODI::SHADER::VideoShaderPreset m_videoShader;
   };
 } // namespace SHADERPRESET

--- a/xbmc/cores/RetroPlayer/VideoShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/VideoShaderPreset.h
@@ -65,7 +65,6 @@ namespace SHADERPRESET
     // Instance of CShaderPreset
     static std::unique_ptr<ADDON::CShaderPresetAddon> shaderPresetAddon;
     explicit CVideoShaderPreset();
-    explicit CVideoShaderPreset(std::string presetPath);
 
     // Initializes CShaderPresetAddon instance that's used for calling the add-on's functions
     bool Init() override;

--- a/xbmc/cores/RetroPlayer/guicontrols/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/guicontrols/CMakeLists.txt
@@ -1,5 +1,9 @@
-set(SOURCES GUIGameControl.cpp)
+set(SOURCES GUIGameControl.cpp
+            GUIGameControlManager.cpp
+)
 
-set(HEADERS GUIGameControl.h)
+set(HEADERS GUIGameControl.h
+            GUIGameControlManager.h
+)
 
 core_add_library(retroplayer_guicontrols)

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIGameControl.h"
-#include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
+#include "GUIGameControlManager.h"
 #include "games/GameServices.h"
 #include "guilib/Geometry.h"
 #include "guilib/GraphicContext.h"
@@ -125,43 +125,36 @@ bool CGUIGameControl::CanFocus() const
 
 void CGUIGameControl::UpdateInfo(const CGUIListItem *item /* = nullptr */)
 {
-  m_viewMode = -1;
-  m_scalingMethod = -1;
+  m_renderSettings.Reset();
 
   if (item)
   {
     std::string strViewMode = m_viewModeInfo.GetItemLabel(item);
     if (StringUtils::IsNaturalNumber(strViewMode))
-      std::istringstream(std::move(strViewMode)) >> m_viewMode;
+    {
+      unsigned int viewMode;
+      std::istringstream(std::move(strViewMode)) >> viewMode;
+      m_renderSettings.SetRenderViewMode(static_cast<ViewMode>(viewMode));
+    }
 
     std::string strVideoFilter = m_videoFilterInfo.GetItemLabel(item);
     if (StringUtils::IsNaturalNumber(strVideoFilter))
-      std::istringstream(std::move(strVideoFilter)) >> m_scalingMethod;
+    {
+      unsigned int scalingMethod;
+      std::istringstream(std::move(strVideoFilter)) >> scalingMethod;
+      m_renderSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
+    }
   }
 }
 
 void CGUIGameControl::EnableGUIRender()
 {
-  CGUIRenderSettings &renderSettings = CServiceBroker::GetGameServices().RenderSettings();
-  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
-
-  renderSettings.EnableGuiRenderSettings(true);
-
-  // Set view mode
-  if (m_viewMode >= 0)
-    renderSettings.SetRenderViewMode(static_cast<ViewMode>(m_viewMode));
-  else
-    renderSettings.SetRenderViewMode(gameSettings.ViewMode());
-
-  // Set scaling method
-  if (m_scalingMethod >= 0)
-    renderSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(m_scalingMethod));
-  else
-    renderSettings.SetScalingMethod(gameSettings.ScalingMethod());
+  CGUIGameControlManager &gameControls = CServiceBroker::GetGameServices().GameControls();
+  gameControls.SetActiveControl(this);
 }
 
 void CGUIGameControl::DisableGUIRender()
 {
-  CGUIRenderSettings &renderSettings = CServiceBroker::GetGameServices().RenderSettings();
-  renderSettings.EnableGuiRenderSettings(false);
+  CGUIGameControlManager &gameControls = CServiceBroker::GetGameServices().GameControls();
+  gameControls.ResetActiveControl();
 }

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -129,20 +129,16 @@ void CGUIGameControl::UpdateInfo(const CGUIListItem *item /* = nullptr */)
 
   if (item)
   {
+    std::string videoFilter = m_videoFilterInfo.GetItemLabel(item);
+    if (!videoFilter.empty())
+      m_renderSettings.SetVideoFilter(videoFilter);
+
     std::string strViewMode = m_viewModeInfo.GetItemLabel(item);
     if (StringUtils::IsNaturalNumber(strViewMode))
     {
       unsigned int viewMode;
       std::istringstream(std::move(strViewMode)) >> viewMode;
       m_renderSettings.SetRenderViewMode(static_cast<ViewMode>(viewMode));
-    }
-
-    std::string strVideoFilter = m_videoFilterInfo.GetItemLabel(item);
-    if (StringUtils::IsNaturalNumber(strVideoFilter))
-    {
-      unsigned int scalingMethod;
-      std::istringstream(std::move(strVideoFilter)) >> scalingMethod;
-      m_renderSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIInfoTypes.h"
 
@@ -28,6 +29,7 @@ namespace KODI
 {
 namespace RETRO
 {
+class CGUIRenderSettings;
 
 class CGUIGameControl : public CGUIControl
 {
@@ -37,6 +39,8 @@ public:
 
   void SetViewMode(const CGUIInfoLabel &viewMode);
   void SetVideoFilter(const CGUIInfoLabel &videoFilter);
+
+  const CGUIRenderSettings &GetRenderSettings() const { return m_renderSettings; }
 
   // implementation of CGUIControl
   CGUIGameControl *Clone() const override { return new CGUIGameControl(*this); };
@@ -53,8 +57,7 @@ private:
   CGUIInfoLabel m_viewModeInfo;
   CGUIInfoLabel m_videoFilterInfo;
 
-  int m_viewMode = -1;
-  int m_scalingMethod = -1;
+  CGUIRenderSettings m_renderSettings;
 };
 
 }

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControlManager.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControlManager.cpp
@@ -1,0 +1,50 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIGameControlManager.h"
+#include "GUIGameControl.h"
+#include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+void CGUIGameControlManager::SetActiveControl(CGUIGameControl *control)
+{
+  m_activeControl = control;
+}
+
+bool CGUIGameControlManager::IsControlActive() const
+{
+  return m_activeControl != nullptr;
+}
+
+void CGUIGameControlManager::ResetActiveControl()
+{
+  m_activeControl = nullptr;
+}
+
+const CGUIRenderSettings &CGUIGameControlManager::GetRenderSettings() const
+{
+  if (m_activeControl != nullptr)
+    return m_activeControl->GetRenderSettings();
+
+  static const CGUIRenderSettings defaultSettings;
+  return defaultSettings;
+}

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControlManager.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControlManager.h
@@ -19,34 +19,29 @@
  */
 #pragma once
 
-#include "cores/IPlayer.h"
+#include "guilib/GUIControl.h"
+#include "guilib/GUIInfoTypes.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CGUIRenderSettings
+  class CGUIGameControl;
+  class CGUIRenderSettings;
+
+  class CGUIGameControlManager
   {
   public:
-    CGUIRenderSettings() { Reset(); }
+    CGUIGameControlManager() = default;
 
-    void Reset();
+    void SetActiveControl(CGUIGameControl *control);
+    bool IsControlActive() const;
+    void ResetActiveControl();
 
-    bool operator==(const CGUIRenderSettings &rhs) const;
-
-    ViewMode GetRenderViewMode() const;
-    bool HasRenderViewMode() const { return m_viewMode != -1; }
-    void SetRenderViewMode(ViewMode mode) { m_viewMode = static_cast<int>(mode); }
-    void ResetRenderViewMode() { m_viewMode = -1; }
-
-    ESCALINGMETHOD GetScalingMethod() const;
-    bool HasScalingMethod() const { return m_scalingMethod != -1; }
-    void SetScalingMethod(ESCALINGMETHOD method) { m_scalingMethod = static_cast<int>(method); }
-    void ResetScalingMethod() { m_scalingMethod = -1; }
+    const CGUIRenderSettings &GetRenderSettings() const;
 
   private:
-    int m_viewMode;
-    int m_scalingMethod;
+    CGUIGameControl *m_activeControl = nullptr;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
@@ -2,7 +2,9 @@ set(SOURCES GUIRenderSettings.cpp
             RPRenderManager.cpp
             VideoShader.cpp
             VideoShaderLUT.cpp
-            VideoShaderManager.cpp)
+            VideoShaderManager.cpp
+            VideoShaderPresetFactory.cpp
+)
 
 set(HEADERS GUIRenderSettings.h
             IRenderSettingsCallback.h
@@ -10,6 +12,8 @@ set(HEADERS GUIRenderSettings.h
             VideoShader.h
             VideoShaderManager.h
             VideoShaderLUT.h
-            VideoShaderUtils.h)
+            VideoShaderPresetFactory.h
+            VideoShaderUtils.h
+)
 
 core_add_library(rp-rendering)

--- a/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES RPRenderManager.cpp
+set(SOURCES GUIRenderSettings.cpp
+            RPRenderManager.cpp
             VideoShader.cpp
             VideoShaderLUT.cpp
             VideoShaderManager.cpp)

--- a/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIRenderSettings.h"
+#include "settings/GameSettings.h"
+#include "settings/MediaSettings.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+void CGUIRenderSettings::Reset()
+{
+  m_viewMode = -1;
+  m_scalingMethod = -1;
+}
+
+bool CGUIRenderSettings::operator==(const CGUIRenderSettings &rhs) const
+{
+  return m_viewMode == rhs.m_viewMode &&
+         m_scalingMethod == rhs.m_scalingMethod;
+}
+
+ViewMode CGUIRenderSettings::GetRenderViewMode() const
+{
+  if (HasRenderViewMode())
+    return static_cast<ViewMode>(m_viewMode);
+  
+  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+  return gameSettings.ViewMode();
+}
+
+ESCALINGMETHOD CGUIRenderSettings::GetScalingMethod() const
+{
+  if (HasScalingMethod())
+    return static_cast<ESCALINGMETHOD>(m_scalingMethod);
+
+  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+  return gameSettings.ScalingMethod();
+}

--- a/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
@@ -27,14 +27,23 @@ using namespace RETRO;
 
 void CGUIRenderSettings::Reset()
 {
+  m_videoFilter.clear();
   m_viewMode = -1;
-  m_scalingMethod = -1;
 }
 
 bool CGUIRenderSettings::operator==(const CGUIRenderSettings &rhs) const
 {
-  return m_viewMode == rhs.m_viewMode &&
-         m_scalingMethod == rhs.m_scalingMethod;
+  return m_videoFilter == rhs.m_videoFilter &&
+         m_viewMode == rhs.m_viewMode;
+}
+
+std::string CGUIRenderSettings::GetVideoFilter() const
+{
+  if (HasVideoFilter())
+    return m_videoFilter;
+
+  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+  return gameSettings.VideoFilter();
 }
 
 ViewMode CGUIRenderSettings::GetRenderViewMode() const
@@ -44,13 +53,4 @@ ViewMode CGUIRenderSettings::GetRenderViewMode() const
   
   CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
   return gameSettings.ViewMode();
-}
-
-ESCALINGMETHOD CGUIRenderSettings::GetScalingMethod() const
-{
-  if (HasScalingMethod())
-    return static_cast<ESCALINGMETHOD>(m_scalingMethod);
-
-  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
-  return gameSettings.ScalingMethod();
 }

--- a/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.h
+++ b/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.h
@@ -34,19 +34,19 @@ namespace RETRO
 
     bool operator==(const CGUIRenderSettings &rhs) const;
 
+    std::string GetVideoFilter() const;
+    bool HasVideoFilter() const { return !m_videoFilter.empty(); }
+    void SetVideoFilter(const std::string &videoFilter) { m_videoFilter = videoFilter; }
+    void ResetVideoFilter() { m_videoFilter.clear(); }
+
     ViewMode GetRenderViewMode() const;
     bool HasRenderViewMode() const { return m_viewMode != -1; }
     void SetRenderViewMode(ViewMode mode) { m_viewMode = static_cast<int>(mode); }
     void ResetRenderViewMode() { m_viewMode = -1; }
 
-    ESCALINGMETHOD GetScalingMethod() const;
-    bool HasScalingMethod() const { return m_scalingMethod != -1; }
-    void SetScalingMethod(ESCALINGMETHOD method) { m_scalingMethod = static_cast<int>(method); }
-    void ResetScalingMethod() { m_scalingMethod = -1; }
-
   private:
+    std::string m_videoFilter;
     int m_viewMode;
-    int m_scalingMethod;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/IRenderSettingsCallback.h
+++ b/xbmc/cores/RetroPlayer/rendering/IRenderSettingsCallback.h
@@ -32,15 +32,12 @@ namespace RETRO
     virtual ~IRenderSettingsCallback() = default;
 
     virtual bool SupportsRenderFeature(ERENDERFEATURE feature) = 0;
-    virtual bool SupportsScalingMethod(ESCALINGMETHOD method) = 0;
+
+    virtual void SetShaderPreset(const std::string& shaderPresetPath) = 0;
+    virtual const std::string &GetShaderPreset() = 0;
 
     virtual ViewMode GetRenderViewMode() = 0;
     virtual void SetRenderViewMode(ViewMode mode) = 0;
-
-    virtual ESCALINGMETHOD GetScalingMethod() = 0;
-    virtual void SetScalingMethod(ESCALINGMETHOD scalingMethod) = 0;
-    virtual void SetShaderPreset(const std::string& shaderPresetPath) = 0;
-    virtual const std::string& GetShaderPreset() = 0;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -173,48 +173,17 @@ void CRPRenderManager::FrameMove()
   ManageCaptures();
 }
 
-// Implementation of IVideoSelectCallback
-
-bool CRPRenderManager::SupportsRenderFeature(ERENDERFEATURE feature)
-{
-  return Supports(feature);
-}
-
 void CRPRenderManager::SetSpeed(double speed)
 {
   if (m_pRenderer)
     m_pRenderer->SetSpeed(speed);
 }
 
-bool CRPRenderManager::SupportsScalingMethod(ESCALINGMETHOD method)
-{
-  return Supports(method);
-}
+// Implementation of IVideoSelectCallback
 
-ViewMode CRPRenderManager::GetRenderViewMode()
+bool CRPRenderManager::SupportsRenderFeature(ERENDERFEATURE feature)
 {
-  //! @todo
-  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
-  return static_cast<ViewMode>(videoSettings.m_ViewMode);
-}
-
-void CRPRenderManager::SetRenderViewMode(ViewMode mode)
-{
-  SetViewMode(mode);
-}
-
-ESCALINGMETHOD CRPRenderManager::GetScalingMethod()
-{
-  //! @todo
-  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
-  return videoSettings.m_ScalingMethod;
-}
-
-void CRPRenderManager::SetScalingMethod(ESCALINGMETHOD method)
-{
-  //! @todo
-  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
-  videoSettings.m_ScalingMethod = method;
+  return Supports(feature);
 }
 
 // TODO: Avoid casting by adding SetShaderPreset method to BaseRenderer
@@ -228,8 +197,20 @@ void CRPRenderManager::SetShaderPreset(const std::string& shaderPresetPath)
 // TODO: Avoid casting by adding GetShaderPreset method to BaseRenderer
 const std::string& CRPRenderManager::GetShaderPreset()
 {
-   CRPWinRenderer* winRenderer = nullptr;
-   if ((winRenderer = dynamic_cast<CRPWinRenderer*>(m_pRenderer)))
-      return winRenderer->GetShaderPreset();
-   return "";
+  CRPWinRenderer* winRenderer = nullptr;
+  if ((winRenderer = dynamic_cast<CRPWinRenderer*>(m_pRenderer)))
+    return winRenderer->GetShaderPreset();
+  return "";
+}
+
+ViewMode CRPRenderManager::GetRenderViewMode()
+{
+  //! @todo
+  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
+  return static_cast<ViewMode>(videoSettings.m_ViewMode);
+}
+
+void CRPRenderManager::SetRenderViewMode(ViewMode mode)
+{
+  SetViewMode(mode);
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -33,7 +33,6 @@ namespace RETRO
     CRPRenderManager(CDVDClock &clock, IRenderMsg *player);
     ~CRPRenderManager() override = default;
 
-    // Implementation of IRenderSettingsCallback
     void PreInit();
     void CreateRenderer();
     bool Configure();
@@ -42,14 +41,11 @@ namespace RETRO
     void SetSpeed(double speed);
 
     // Implementation of IRenderSettingsCallback
-    bool SupportsScalingMethod(ESCALINGMETHOD method) override;
     bool SupportsRenderFeature(ERENDERFEATURE feature) override;
+    void SetShaderPreset(const std::string &shaderPresetPath) override;
+    const std::string &GetShaderPreset() override;
     ViewMode GetRenderViewMode() override;
     void SetRenderViewMode(ViewMode mode) override;
-    void SetScalingMethod(ESCALINGMETHOD method) override;
-    void SetShaderPreset(const std::string& shaderPresetPath) override;
-    ESCALINGMETHOD GetScalingMethod() override;
-    const std::string& GetShaderPreset() override;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -25,6 +25,9 @@
 #include "windowing/windows/WinSystemWin32DX.h"
 #include "utils/log.h"
 
+using namespace KODI;
+using namespace SHADER;
+
 CRPWinRenderer::CRPWinRenderer()
   : CWinRenderer()
   , m_shadersNeedUpdate(true)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -70,7 +70,7 @@ protected:
   // ====== Video Shader Members =====
 private:
   // For true renderer independence, RPRenderManager must own this
-  std::unique_ptr<CVideoShaderManager> m_shaderManager;
+  std::unique_ptr<KODI::SHADER::CVideoShaderManager> m_shaderManager;
 
 public:
   /**

--- a/xbmc/cores/RetroPlayer/rendering/VideoShader.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShader.cpp
@@ -25,6 +25,7 @@
 #include "Application.h"
 #include "guilib/Texture.h"
 
+using namespace KODI;
 using namespace SHADER;
 
 CVideoShader::CVideoShader()

--- a/xbmc/cores/RetroPlayer/rendering/VideoShader.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShader.h
@@ -23,7 +23,10 @@
 #include "VideoRenderers/VideoShaders/WinVideoFilter.h"
 #include "VideoShaderLUT.h"
 
-using namespace SHADER;
+namespace KODI
+{
+namespace SHADER
+{
 
 class CVideoPixelShader : public CD3DPixelShader
 {
@@ -109,3 +112,6 @@ private:
 private:
   cbInput GetInputData(float frameCount = 0);
 };
+
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.cpp
@@ -26,9 +26,10 @@
 
 #include <regex>
 
+using namespace KODI;
 using namespace SHADER;
 
-ID3D11SamplerState* SHADER::CreateLUTSampler(const video_shader_lut lut)
+ID3D11SamplerState* SHADER::CreateLUTSampler(const VideoShaderLut &lut)
 {
   ID3D11SamplerState* samp;
   D3D11_SAMPLER_DESC sampDesc;
@@ -50,14 +51,14 @@ ID3D11SamplerState* SHADER::CreateLUTSampler(const video_shader_lut lut)
 
   if (FAILED(g_Windowing.Get3D11Device()->CreateSamplerState(&sampDesc, &samp)))
   {
-    CLog::Log(LOGWARNING, "%s - failed to create LUT sampler for LUT &s", __FUNCTION__, lut.path);
+    CLog::Log(LOGWARNING, "%s - failed to create LUT sampler for LUT &s", __FUNCTION__, lut.path.c_str());
     return nullptr;
   }
 
   return samp;
 }
 
-CDXTexture* SHADER::CreateLUTexture(video_shader_lut lut, const std::string& presetDirectory)
+CDXTexture* SHADER::CreateLUTexture(const VideoShaderLut &lut, const std::string& presetDirectory)
 {
   const std::string& texturePath =
     URIUtils::AddFileToFolder(
@@ -81,17 +82,17 @@ CDXTexture* SHADER::CreateLUTexture(video_shader_lut lut, const std::string& pre
   return texture;
 }
 
-D3D11_TEXTURE_ADDRESS_MODE SHADER::TranslateWrapType(gfx_wrap_type wrap)
+D3D11_TEXTURE_ADDRESS_MODE SHADER::TranslateWrapType(WRAP_TYPE wrap)
 {
   switch(wrap)
   {
-  case RARCH_WRAP_EDGE:
+  case WRAP_TYPE_EDGE:
     return D3D11_TEXTURE_ADDRESS_CLAMP;
-  case RARCH_WRAP_REPEAT:
+  case WRAP_TYPE_REPEAT:
     return D3D11_TEXTURE_ADDRESS_WRAP;
-  case RARCH_WRAP_MIRRORED_REPEAT:
+  case WRAP_TYPE_MIRRORED_REPEAT:
     return D3D11_TEXTURE_ADDRESS_MIRROR;
-  case RARCH_WRAP_BORDER:
+  case WRAP_TYPE_BORDER:
   default:
     return D3D11_TEXTURE_ADDRESS_BORDER;
   }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.cpp
@@ -23,13 +23,12 @@
 #include "utils/log.h"
 #include "windowing/WindowingFactory.h"
 #include "guilib/Texture.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 
 #include <regex>
 
 using namespace SHADER;
 
-ID3D11SamplerState* SHADER::CreateLUTSampler(const video_shader_lut_ lut)
+ID3D11SamplerState* SHADER::CreateLUTSampler(const video_shader_lut lut)
 {
   ID3D11SamplerState* samp;
   D3D11_SAMPLER_DESC sampDesc;
@@ -58,7 +57,7 @@ ID3D11SamplerState* SHADER::CreateLUTSampler(const video_shader_lut_ lut)
   return samp;
 }
 
-CDXTexture* SHADER::CreateLUTexture(const video_shader_lut_ lut, const std::string& presetDirectory)
+CDXTexture* SHADER::CreateLUTexture(video_shader_lut lut, const std::string& presetDirectory)
 {
   const std::string& texturePath =
     URIUtils::AddFileToFolder(
@@ -82,17 +81,17 @@ CDXTexture* SHADER::CreateLUTexture(const video_shader_lut_ lut, const std::stri
   return texture;
 }
 
-D3D11_TEXTURE_ADDRESS_MODE SHADER::TranslateWrapType(const gfx_wrap_type_ wrap)
+D3D11_TEXTURE_ADDRESS_MODE SHADER::TranslateWrapType(gfx_wrap_type wrap)
 {
   switch(wrap)
   {
-  case RARCH_WRAP_EDGE_:
+  case RARCH_WRAP_EDGE:
     return D3D11_TEXTURE_ADDRESS_CLAMP;
-  case RARCH_WRAP_REPEAT_:
+  case RARCH_WRAP_REPEAT:
     return D3D11_TEXTURE_ADDRESS_WRAP;
-  case RARCH_WRAP_MIRRORED_REPEAT_:
+  case RARCH_WRAP_MIRRORED_REPEAT:
     return D3D11_TEXTURE_ADDRESS_MIRROR;
-  case RARCH_WRAP_DEFAULT_:
+  case RARCH_WRAP_BORDER:
   default:
     return D3D11_TEXTURE_ADDRESS_BORDER;
   }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.h
@@ -21,11 +21,10 @@
 
 #include <memory>
 #include <string>
+#include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 #include "system.h"
 #include "VideoShaderUtils.h"
 
-struct video_shader_lut_;
-enum gfx_wrap_type_;
 class CDXTexture;
 
 namespace SHADER
@@ -70,12 +69,12 @@ namespace SHADER
     ShaderLUT& operator=(const ShaderLUT& rhs) = delete;
   };
 
-  ID3D11SamplerState* CreateLUTSampler(const video_shader_lut_ lut);
-  CDXTexture* CreateLUTexture(const video_shader_lut_ lut, const std::string& presetDirectory);
+  ID3D11SamplerState* CreateLUTSampler(video_shader_lut lut);
+  CDXTexture* CreateLUTexture(video_shader_lut lut, const std::string& presetDirectory);
 
   // Returns smallest possible power-of-two sized texture
   float2 GetOptimalTextureSize(float2 videoSize);
-  D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(const gfx_wrap_type_ wrap);
+  D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(gfx_wrap_type wrap);
 
   typedef std::vector<std::shared_ptr<ShaderLUT>> ShaderLUTs;
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderLUT.h
@@ -24,9 +24,12 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 #include "system.h"
 #include "VideoShaderUtils.h"
+#include "cores/RetroPlayer/IVideoShaderPreset.h"
 
 class CDXTexture;
 
+namespace KODI
+{
 namespace SHADER
 {
   struct ShaderLUT
@@ -69,12 +72,13 @@ namespace SHADER
     ShaderLUT& operator=(const ShaderLUT& rhs) = delete;
   };
 
-  ID3D11SamplerState* CreateLUTSampler(video_shader_lut lut);
-  CDXTexture* CreateLUTexture(video_shader_lut lut, const std::string& presetDirectory);
+  ID3D11SamplerState* CreateLUTSampler(const VideoShaderLut &lut);
+  CDXTexture* CreateLUTexture(const VideoShaderLut &lut, const std::string& presetDirectory);
 
   // Returns smallest possible power-of-two sized texture
   float2 GetOptimalTextureSize(float2 videoSize);
-  D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(gfx_wrap_type wrap);
+  D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(WRAP_TYPE wrap);
 
   typedef std::vector<std::shared_ptr<ShaderLUT>> ShaderLUTs;
+}
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -216,26 +216,26 @@ bool CVideoShaderManager::CreateShaderTextures()
     UINT textureY;
     switch (pass.fbo.type_x)
     {
-    case RARCH_SCALE_ABSOLUTE_:
+    case RARCH_SCALE_ABSOLUTE:
       textureX = pass.fbo.abs_x;
       break;
-    case RARCH_SCALE_VIEWPORT_:
+    case RARCH_SCALE_VIEWPORT:
       textureX = m_outputSize.x;
       break;
-    case RARCH_SCALE_INPUT_:
+    case RARCH_SCALE_INPUT:
     default:
       textureX = prevSize.x;
       break;
     }
     switch (pass.fbo.type_y)
     {
-    case RARCH_SCALE_ABSOLUTE_:
+    case RARCH_SCALE_ABSOLUTE:
       textureY = pass.fbo.abs_y;
       break;
-    case RARCH_SCALE_VIEWPORT_:
+    case RARCH_SCALE_VIEWPORT:
       textureY = m_outputSize.y;
       break;
-    case RARCH_SCALE_INPUT_:
+    case RARCH_SCALE_INPUT:
     default:
       textureY = prevSize.y;
       break;
@@ -300,7 +300,7 @@ bool CVideoShaderManager::CreateShaders()
   ShaderLUTs passLUTs;
   for(unsigned i = 0; i < m_pPreset->m_Luts; ++i)
   {
-    video_shader_lut_& lutStruct = m_pPreset->m_Lut[i];
+    video_shader_lut& lutStruct = m_pPreset->m_Lut[i];
 
     ID3D11SamplerState* lutSampler(CreateLUTSampler(lutStruct));
     CDXTexture* lutTexture(CreateLUTexture(lutStruct, presetDirectory));
@@ -394,7 +394,7 @@ bool CVideoShaderManager::CreateBuffers()
   return true;
 }
 
-ShaderParameters CVideoShaderManager::GetShaderParameters(video_shader_parameter_* parameters,
+ShaderParameters CVideoShaderManager::GetShaderParameters(video_shader_parameter* parameters,
    unsigned numParameters, const std::string& sourceStr) const
 {
    static const std::regex pragmaParamRegex("#pragma parameter ([a-zA-Z_][a-zA-Z0-9_]*)");

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -43,9 +43,6 @@ CVideoShaderManager::CVideoShaderManager(CBaseRenderer& rendererRef, unsigned vi
 {
   m_videoSize = { videoWidth, videoHeight };
 
-  m_pVideoShaders.reserve(GFX_MAX_SHADERS);
-  m_pShaderTextures.reserve(GFX_MAX_SHADERS);
-
   CRect viewPort;
   g_Windowing.GetViewPort(viewPort);
   m_outputSize = float2(viewPort.Width(), viewPort.Height());
@@ -216,26 +213,26 @@ bool CVideoShaderManager::CreateShaderTextures()
     UINT textureY;
     switch (pass.fbo.scaleX.type)
     {
-    case RARCH_SCALE_ABSOLUTE:
+    case SCALE_TYPE_ABSOLUTE:
       textureX = pass.fbo.scaleX.abs;
       break;
-    case RARCH_SCALE_VIEWPORT:
+    case SCALE_TYPE_VIEWPORT:
       textureX = m_outputSize.x;
       break;
-    case RARCH_SCALE_INPUT:
+    case SCALE_TYPE_INPUT:
     default:
       textureX = prevSize.x;
       break;
     }
     switch (pass.fbo.scaleY.type)
     {
-    case RARCH_SCALE_ABSOLUTE:
+    case SCALE_TYPE_ABSOLUTE:
       textureY = pass.fbo.scaleY.abs;
       break;
-    case RARCH_SCALE_VIEWPORT:
+    case SCALE_TYPE_VIEWPORT:
       textureY = m_outputSize.y;
       break;
-    case RARCH_SCALE_INPUT:
+    case SCALE_TYPE_INPUT:
     default:
       textureY = prevSize.y;
       break;

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -25,12 +25,12 @@
 #include "windowing/WindowingFactory.h"
 #include "cores/RetroPlayer/rendering/VideoShader.h"
 #include "cores/RetroPlayer/rendering/VideoShaderLUT.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h"
 
 #include <regex>
 #include "cores/RetroPlayer/RetroPlayer.h"
 #include "settings/DisplaySettings.h"
 
+using namespace KODI;
 using namespace SHADER;
 
 CVideoShaderManager::CVideoShaderManager(CBaseRenderer& rendererRef, unsigned videoWidth, unsigned videoHeight)
@@ -205,19 +205,19 @@ bool CVideoShaderManager::CreateShaderTextures()
 
   float2 prevSize = m_videoSize;
 
-  auto numPasses = std::min(m_pPreset->m_Passes, static_cast<unsigned>(GFX_MAX_SHADERS));
+  auto numPasses = m_pPreset->Preset().passes.size();
 
   for (unsigned shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx) {
-    auto& pass = m_pPreset->m_Pass[shaderIdx];
+    auto& pass = m_pPreset->Preset().passes[shaderIdx];
 
     // resolve final texture resolution, taking scale type and scale multiplier into account
 
     UINT textureX;
     UINT textureY;
-    switch (pass.fbo.scale_x.type)
+    switch (pass.fbo.scaleX.type)
     {
     case RARCH_SCALE_ABSOLUTE:
-      textureX = pass.fbo.scale_x.abs;
+      textureX = pass.fbo.scaleX.abs;
       break;
     case RARCH_SCALE_VIEWPORT:
       textureX = m_outputSize.x;
@@ -227,10 +227,10 @@ bool CVideoShaderManager::CreateShaderTextures()
       textureX = prevSize.x;
       break;
     }
-    switch (pass.fbo.scale_y.type)
+    switch (pass.fbo.scaleY.type)
     {
     case RARCH_SCALE_ABSOLUTE:
-      textureY = pass.fbo.scale_y.abs;
+      textureY = pass.fbo.scaleY.abs;
       break;
     case RARCH_SCALE_VIEWPORT:
       textureY = m_outputSize.y;
@@ -242,7 +242,7 @@ bool CVideoShaderManager::CreateShaderTextures()
     }
 
     // if the scale was unspecified
-    if (pass.fbo.scale_x.scale == 0 && pass.fbo.scale_y.scale == 0)
+    if (pass.fbo.scaleX.scale == 0 && pass.fbo.scaleY.scale == 0)
     {
       // if the last shader has the scale unspecified
       if (shaderIdx == numPasses - 1)
@@ -255,8 +255,8 @@ bool CVideoShaderManager::CreateShaderTextures()
     }
     else
     {
-      textureX *= pass.fbo.scale_x.scale;
-      textureY *= pass.fbo.scale_y.scale;
+      textureX *= pass.fbo.scaleX.scale;
+      textureY *= pass.fbo.scaleY.scale;
     }
 
     // For reach pass, create the texture
@@ -264,18 +264,18 @@ bool CVideoShaderManager::CreateShaderTextures()
 
     // Determine the framebuffer data format
     DXGI_FORMAT textureFormat;
-    if (pass.fbo.fp_fbo)
+    if (pass.fbo.floatFramebuffer)
       // Give priority to float framebuffer parameter (we can't use both float and sRGB)
       textureFormat = DXGI_FORMAT_R32G32B32A32_FLOAT;
     else
-      if (pass.fbo.srgb_fbo)
+      if (pass.fbo.sRgbFramebuffer)
         textureFormat = DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
       else
         textureFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 
     if (!texture->Create(textureX, textureY, 1, D3D11_USAGE_DEFAULT, textureFormat, nullptr, 0))
     {
-      CLog::Log(LOGERROR, "Couldn't create a texture for video shader %s.", pass.source_path);
+      CLog::Log(LOGERROR, "Couldn't create a texture for video shader %s.", pass.sourcePath.c_str());
       return false;
     }
     m_pShaderTextures.push_back(std::move(texture));
@@ -290,45 +290,45 @@ bool CVideoShaderManager::CreateShaderTextures()
 
 bool CVideoShaderManager::CreateShaders()
 {
-  auto numPasses = std::min(m_pPreset->m_Passes, static_cast<unsigned>(GFX_MAX_SHADERS));
-  auto numParameters = std::min(m_pPreset->m_NumParameters, static_cast<unsigned>(GFX_MAX_PARAMETERS));
+  auto numPasses = m_pPreset->Preset().passes.size();
+  auto numParameters = m_pPreset->Preset().parameters.size();
   m_textureSize = GetOptimalTextureSize(m_videoSize); // todo: replace with per-shader texture size
   // TODO: Bad! Should pass full paths at add-on side like we did with shader paths
   auto presetDirectory = URIUtils::AddFileToFolder("special://xbmcbinaddons/game.shader.presets/resources/libretro/hlsl", m_videoShaderPath);
 
   // todo: is this pass specific?
   ShaderLUTs passLUTs;
-  for(unsigned i = 0; i < m_pPreset->m_Luts; ++i)
+  for(unsigned i = 0; i < m_pPreset->Preset().luts.size(); ++i)
   {
-    video_shader_lut& lutStruct = m_pPreset->m_Lut[i];
+    const VideoShaderLut& lutStruct = m_pPreset->Preset().luts[i];
 
     ID3D11SamplerState* lutSampler(CreateLUTSampler(lutStruct));
     CDXTexture* lutTexture(CreateLUTexture(lutStruct, presetDirectory));
 
     if (!lutSampler || !lutTexture)
     {
-      CLog::Log(LOGWARNING, "%s - Couldn't create a LUT sampler or texture for LUT %s", __FUNCTION__, lutStruct.id);
+      CLog::Log(LOGWARNING, "%s - Couldn't create a LUT sampler or texture for LUT %s", __FUNCTION__, lutStruct.strId);
       delete lutSampler;
       delete lutTexture;
     }
     else
-      passLUTs.emplace_back(new ShaderLUT(lutStruct.id, lutStruct.path, lutSampler, lutTexture));
+      passLUTs.emplace_back(new ShaderLUT(lutStruct.strId, lutStruct.path, lutSampler, lutTexture));
   }
 
   for (unsigned shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx) {
-    auto& pass = m_pPreset->m_Pass[shaderIdx];
+    const auto& pass = m_pPreset->Preset().passes[shaderIdx];
 
     // For reach pass, create the shader
     std::unique_ptr<CVideoShader> videoShader(new CVideoShader());
 
-    auto shaderSrc = pass.vertex_source; // also contains fragment source
-    auto shaderPath = pass.source_path;
+    auto shaderSrc = pass.vertexSource; // also contains fragment source
+    auto shaderPath = pass.sourcePath;
 
     // Get only the parameters belonging to this specific shader
-    ShaderParameters passParameters = GetShaderParameters(m_pPreset->m_Parameters, numParameters, pass.vertex_source);
+    ShaderParameters passParameters = GetShaderParameters(m_pPreset->Preset().parameters, pass.vertexSource);
     ID3D11SamplerState* passSampler = pass.filter ? m_pSampLinear : m_pSampNearest;
 
-    if (!videoShader->Create(shaderSrc, shaderPath, passParameters, passSampler, passLUTs, m_outputSize, pass.frame_count_mod))
+    if (!videoShader->Create(shaderSrc, shaderPath, passParameters, passSampler, passLUTs, m_outputSize, pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "Couldn't create a video shader");
       return false;
@@ -394,8 +394,7 @@ bool CVideoShaderManager::CreateBuffers()
   return true;
 }
 
-ShaderParameters CVideoShaderManager::GetShaderParameters(video_shader_parameter* parameters,
-   unsigned numParameters, const std::string& sourceStr) const
+ShaderParameters CVideoShaderManager::GetShaderParameters(const std::vector<VideoShaderParameter> &parameters, const std::string& sourceStr) const
 {
    static const std::regex pragmaParamRegex("#pragma parameter ([a-zA-Z_][a-zA-Z0-9_]*)");
    std::smatch matches;
@@ -410,8 +409,8 @@ ShaderParameters CVideoShaderManager::GetShaderParameters(video_shader_parameter
 
    ShaderParameters matchParams;
    for (const auto& match : validParams)   // for each param found in the source code
-      for (unsigned i = 0; i < numParameters; ++i)  // for each param found in the preset file
-         if (match == parameters[i].id)  // if they match
+      for (unsigned i = 0; i < parameters.size(); ++i)  // for each param found in the preset file
+         if (match == parameters[i].strId)  // if they match
          {
             // The add-on has already handled parsing and overwriting default
             // parameter values from the preset file. The final value we

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -214,10 +214,10 @@ bool CVideoShaderManager::CreateShaderTextures()
 
     UINT textureX;
     UINT textureY;
-    switch (pass.fbo.type_x)
+    switch (pass.fbo.scale_x.type)
     {
     case RARCH_SCALE_ABSOLUTE:
-      textureX = pass.fbo.abs_x;
+      textureX = pass.fbo.scale_x.abs;
       break;
     case RARCH_SCALE_VIEWPORT:
       textureX = m_outputSize.x;
@@ -227,10 +227,10 @@ bool CVideoShaderManager::CreateShaderTextures()
       textureX = prevSize.x;
       break;
     }
-    switch (pass.fbo.type_y)
+    switch (pass.fbo.scale_y.type)
     {
     case RARCH_SCALE_ABSOLUTE:
-      textureY = pass.fbo.abs_y;
+      textureY = pass.fbo.scale_y.abs;
       break;
     case RARCH_SCALE_VIEWPORT:
       textureY = m_outputSize.y;
@@ -242,7 +242,7 @@ bool CVideoShaderManager::CreateShaderTextures()
     }
 
     // if the scale was unspecified
-    if (pass.fbo.scale_x == 0 && pass.fbo.scale_y == 0)
+    if (pass.fbo.scale_x.scale == 0 && pass.fbo.scale_y.scale == 0)
     {
       // if the last shader has the scale unspecified
       if (shaderIdx == numPasses - 1)
@@ -255,8 +255,8 @@ bool CVideoShaderManager::CreateShaderTextures()
     }
     else
     {
-      textureX *= pass.fbo.scale_x;
-      textureY *= pass.fbo.scale_y;
+      textureX *= pass.fbo.scale_x.scale;
+      textureY *= pass.fbo.scale_y.scale;
     }
 
     // For reach pass, create the texture
@@ -275,7 +275,7 @@ bool CVideoShaderManager::CreateShaderTextures()
 
     if (!texture->Create(textureX, textureY, 1, D3D11_USAGE_DEFAULT, textureFormat, nullptr, 0))
     {
-      CLog::Log(LOGERROR, "Couldn't create a texture for video shader %s.", pass.source.path);
+      CLog::Log(LOGERROR, "Couldn't create a texture for video shader %s.", pass.source_path);
       return false;
     }
     m_pShaderTextures.push_back(std::move(texture));
@@ -321,11 +321,11 @@ bool CVideoShaderManager::CreateShaders()
     // For reach pass, create the shader
     std::unique_ptr<CVideoShader> videoShader(new CVideoShader());
 
-    auto shaderSrc = pass.source.string.vertex; // also contains fragment source
-    auto shaderPath = pass.source.path;
+    auto shaderSrc = pass.vertex_source; // also contains fragment source
+    auto shaderPath = pass.source_path;
 
     // Get only the parameters belonging to this specific shader
-    ShaderParameters passParameters = GetShaderParameters(m_pPreset->m_Parameters, numParameters, pass.source.string.vertex);
+    ShaderParameters passParameters = GetShaderParameters(m_pPreset->m_Parameters, numParameters, pass.vertex_source);
     ID3D11SamplerState* passSampler = pass.filter ? m_pSampLinear : m_pSampNearest;
 
     if (!videoShader->Create(shaderSrc, shaderPath, passParameters, passSampler, passLUTs, m_outputSize, pass.frame_count_mod))

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
@@ -26,10 +26,13 @@
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "guilib/Texture.h"
 
-using namespace SHADER;
+namespace KODI
+{
+namespace SHADER
+{
 
 class CVideoShader;
-struct video_shader_parameter;
+struct VideoShaderParameter;
 
 // TODO: renderer independence
 class CVideoShaderManager
@@ -49,8 +52,7 @@ public:
 
 private:
   bool CreateShaderTextures();
-  ShaderParameters GetShaderParameters(video_shader_parameter* parameters,
-    unsigned numParameters, const std::string& sourceStr) const;
+  ShaderParameters GetShaderParameters(const std::vector<VideoShaderParameter> &parameters, const std::string& sourceStr) const;
   bool CreateShaders();
   //bool CreateIntermediateShader();
   bool CreateSamplers();
@@ -104,3 +106,6 @@ private:
 
   double m_speed = 0.0;
 };
+
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.h
@@ -29,7 +29,7 @@
 using namespace SHADER;
 
 class CVideoShader;
-struct video_shader_parameter_;
+struct video_shader_parameter;
 
 // TODO: renderer independence
 class CVideoShaderManager
@@ -49,7 +49,7 @@ public:
 
 private:
   bool CreateShaderTextures();
-  ShaderParameters GetShaderParameters(video_shader_parameter_* parameters,
+  ShaderParameters GetShaderParameters(video_shader_parameter* parameters,
     unsigned numParameters, const std::string& sourceStr) const;
   bool CreateShaders();
   //bool CreateIntermediateShader();

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
@@ -1,0 +1,139 @@
+/*
+*      Copyright (C) 2017 Team Kodi
+ *     http://kodi.tv
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this Program; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoShaderPresetFactory.h"
+#include "addons/binary-addons/BinaryAddonBase.h"
+#include "addons/binary-addons/BinaryAddonManager.h"
+#include "addons/AddonManager.h"
+#include "addons/ShaderPreset.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+
+#include <algorithm>
+#include <string>
+
+using namespace KODI;
+using namespace SHADER;
+
+CVideoShaderPresetFactory::CVideoShaderPresetFactory(ADDON::CAddonMgr &addons, ADDON::CBinaryAddonManager &binaryAddons) :
+  m_addons(addons),
+  m_binaryAddons(binaryAddons)
+{
+  UpdateAddons();
+
+  m_addons.Events().Subscribe(this, &CVideoShaderPresetFactory::OnEvent);
+}
+
+CVideoShaderPresetFactory::~CVideoShaderPresetFactory()
+{
+  m_addons.Events().Unsubscribe(this);
+}
+
+void CVideoShaderPresetFactory::RegisterLoader(IVideoShaderPresetLoader *loader, const std::string &extension)
+{
+  if (!extension.empty())
+  {
+    std::string strExtension = extension;
+
+    // Canonicalize extension with leading "."
+    if (extension[0] != '.')
+      strExtension.insert(strExtension.begin(), '.');
+
+    m_loaders.insert(std::make_pair(std::move(extension), loader));
+  }
+}
+
+void CVideoShaderPresetFactory::UnregisterLoader(IVideoShaderPresetLoader *loader)
+{
+  for (auto it = m_loaders.begin(); it != m_loaders.end(); )
+  {
+    if (it->second == loader)
+      m_loaders.erase(it++);
+    else
+      ++it;
+  }
+}
+
+bool CVideoShaderPresetFactory::LoadPreset(const std::string &presetPath, VideoShaderPreset &shaderPreset)
+{
+  bool bSuccess = false;
+
+  std::string extension = URIUtils::GetExtension(presetPath);
+  if (!extension.empty())
+  {
+    auto itLoader = m_loaders.find(extension);
+    if (itLoader != m_loaders.end())
+      bSuccess = itLoader->second->LoadPreset(presetPath, shaderPreset);
+  }
+
+  return bSuccess;
+}
+
+void CVideoShaderPresetFactory::OnEvent(const ADDON::AddonEvent &event)
+{
+  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged))
+    UpdateAddons();
+}
+
+void CVideoShaderPresetFactory::UpdateAddons()
+{
+  using namespace ADDON;
+
+  BinaryAddonBaseList addonInfos;
+  m_binaryAddons.GetAddonInfos(addonInfos, true, ADDON_SHADERDLL);
+
+  // Look for removed/disabled add-ons
+  auto oldAddons = std::move(m_shaderAddons);
+  for (auto &shaderAddon : oldAddons)
+  {
+    const bool bIsDisabled = std::find_if(addonInfos.begin(), addonInfos.end(),
+      [&shaderAddon](const BinaryAddonBasePtr &addon)
+      {
+        return shaderAddon->ID() == addon->ID();
+      }) == addonInfos.end();
+
+    if (bIsDisabled)
+      UnregisterLoader(shaderAddon.get());
+    else
+      m_shaderAddons.emplace_back(std::move(shaderAddon));
+  }
+
+  // Look for new add-ons
+  for (const auto &shaderAddon : addonInfos)
+  {
+    const bool bIsNew = std::find_if(m_shaderAddons.begin(), m_shaderAddons.end(),
+      [&shaderAddon](const std::unique_ptr<CShaderPresetAddon> &addon)
+      {
+        return shaderAddon->ID() == addon->ID();
+      }) != m_shaderAddons.end();
+
+    if (bIsNew)
+    {
+      std::unique_ptr<CShaderPresetAddon> addonPtr(new CShaderPresetAddon(shaderAddon));
+
+      for (const auto &extension : addonPtr->GetExtensions())
+        RegisterLoader(addonPtr.get(), extension);
+
+      m_shaderAddons.emplace_back(std::move(addonPtr));
+    }
+  }
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.h
@@ -1,0 +1,76 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "addons/Addon.h"
+#include "xbmc/cores/RetroPlayer/IVideoShaderPreset.h"
+
+#include <map>
+#include <string>
+
+namespace ADDON
+{
+  struct AddonEvent;
+  class CAddonMgr;
+  class CBinaryAddonManager;
+  class CShaderPresetAddon;
+}
+
+namespace KODI
+{
+namespace SHADER
+{
+  class IVideoShaderPreset;
+
+  class IVideoShaderPresetLoader
+  {
+  public:
+    virtual ~IVideoShaderPresetLoader() = default;
+
+    virtual bool LoadPreset(const std::string &presetPath, VideoShaderPreset &shaderPreset) = 0;
+  };
+
+  class CVideoShaderPresetFactory
+  {
+  public:
+    /*!
+     * \brief Create the factory and register all shader preset add-ons
+     */
+    CVideoShaderPresetFactory(ADDON::CAddonMgr &addons, ADDON::CBinaryAddonManager &binaryAddons);
+    ~CVideoShaderPresetFactory();
+
+    void RegisterLoader(IVideoShaderPresetLoader *loader, const std::string &extension);
+    void UnregisterLoader(IVideoShaderPresetLoader *loader);
+
+    bool LoadPreset(const std::string &presetPath, VideoShaderPreset &shaderPreset);
+
+  private:
+    void OnEvent(const ADDON::AddonEvent &event);
+    void UpdateAddons();
+
+    // Construction parameters
+    ADDON::CAddonMgr &m_addons;
+    ADDON::CBinaryAddonManager &m_binaryAddons;
+
+    std::map<std::string, IVideoShaderPresetLoader*> m_loaders;
+    std::vector<std::unique_ptr<ADDON::CShaderPresetAddon>> m_shaderAddons;
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderUtils.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <algorithm>
 
+namespace KODI
+{
 namespace SHADER
 {
   typedef std::map<std::string, float> ShaderParameters;
@@ -62,4 +64,5 @@ namespace SHADER
     FLOAT x, y, z;  // vertex positions
     FLOAT tu, tv;   // texture coordinates
   };
+}
 }

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GameServices.h"
-#include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
+#include "cores/RetroPlayer/guicontrols/GUIGameControlManager.h"
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/ports/PortManager.h"
@@ -31,7 +31,7 @@ using namespace GAME;
 CGameServices::CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager) :
   m_controllerManager(controllerManager),
   m_portManager(new CPortManager(peripheralManager)),
-  m_renderSettings(new RETRO::CGUIRenderSettings)
+  m_gameControlManager(new RETRO::CGUIGameControlManager)
 {
 }
 

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -20,6 +20,7 @@
 
 #include "GameServices.h"
 #include "cores/RetroPlayer/guicontrols/GUIGameControlManager.h"
+#include "cores/RetroPlayer/rendering/VideoShaderPresetFactory.h"
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/ports/PortManager.h"
@@ -28,10 +29,11 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameServices::CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager) :
+CGameServices::CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager, ADDON::CAddonMgr &addons, ADDON::CBinaryAddonManager &binaryAddons) :
   m_controllerManager(controllerManager),
   m_portManager(new CPortManager(peripheralManager)),
-  m_gameControlManager(new RETRO::CGUIGameControlManager)
+  m_gameControlManager(new RETRO::CGUIGameControlManager),
+  m_videoShaders(new SHADER::CVideoShaderPresetFactory(addons, binaryAddons))
 {
 }
 

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -33,7 +33,7 @@ namespace KODI
 {
 namespace RETRO
 {
-  class CGUIRenderSettings;
+  class CGUIGameControlManager;
 }
 
 namespace GAME
@@ -53,7 +53,7 @@ namespace GAME
 
     CPortManager& PortManager();
 
-    RETRO::CGUIRenderSettings& RenderSettings() { return *m_renderSettings; }
+    RETRO::CGUIGameControlManager &GameControls() { return *m_gameControlManager; }
 
   private:
     // Construction parameters
@@ -61,7 +61,7 @@ namespace GAME
 
     // Game services
     std::unique_ptr<CPortManager> m_portManager;
-    std::unique_ptr<RETRO::CGUIRenderSettings> m_renderSettings;
+    std::unique_ptr<RETRO::CGUIGameControlManager> m_gameControlManager;
   };
 }
 }

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -24,6 +24,12 @@
 #include <memory>
 #include <string>
 
+namespace ADDON
+{
+  class CAddonMgr;
+  class CBinaryAddonManager;
+}
+
 namespace PERIPHERALS
 {
   class CPeripherals;
@@ -36,6 +42,11 @@ namespace RETRO
   class CGUIGameControlManager;
 }
 
+namespace SHADER
+{
+  class CVideoShaderPresetFactory;
+}
+
 namespace GAME
 {
   class CControllerManager;
@@ -44,7 +55,7 @@ namespace GAME
   class CGameServices
   {
   public:
-    CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager);
+    CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager, ADDON::CAddonMgr &addons, ADDON::CBinaryAddonManager &binaryAddons);
     ~CGameServices();
 
     ControllerPtr GetController(const std::string& controllerId);
@@ -55,6 +66,8 @@ namespace GAME
 
     RETRO::CGUIGameControlManager &GameControls() { return *m_gameControlManager; }
 
+    SHADER::CVideoShaderPresetFactory &VideoShaders() { return *m_videoShaders; }
+
   private:
     // Construction parameters
     CControllerManager &m_controllerManager;
@@ -62,6 +75,7 @@ namespace GAME
     // Game services
     std::unique_ptr<CPortManager> m_portManager;
     std::unique_ptr<RETRO::CGUIGameControlManager> m_gameControlManager;
+    std::unique_ptr<SHADER::CVideoShaderPresetFactory> m_videoShaders;
   };
 }
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -52,9 +52,6 @@ namespace GAME
     std::vector<VideoFilterProperties> m_videoFilters;
 
     static std::string GetLocalizedString(uint32_t code);
-
-    // relative path of currently loaded shader preset
-    std::string m_shaderPresetPath;
   };
 }
 }

--- a/xbmc/settings/GameSettings.cpp
+++ b/xbmc/settings/GameSettings.cpp
@@ -22,12 +22,12 @@
 
 void CGameSettings::Reset()
 {
-  m_scalingMethod = VS_SCALINGMETHOD_NEAREST;
+  m_videoFilter.clear();
   m_viewMode = ViewModeNormal;
 }
 
 bool CGameSettings::operator==(const CGameSettings &rhs) const
 {
-  return m_scalingMethod == rhs.m_scalingMethod &&
+  return m_videoFilter == rhs.m_videoFilter &&
          m_viewMode == rhs.m_viewMode;
 }

--- a/xbmc/settings/GameSettings.h
+++ b/xbmc/settings/GameSettings.h
@@ -32,14 +32,14 @@ public:
   bool operator==(const CGameSettings &rhs) const;
   bool operator!=(const CGameSettings &rhs) const { return !(*this == rhs); }
 
-  ESCALINGMETHOD ScalingMethod() const { return m_scalingMethod; }
-  void SetScalingMethod(ESCALINGMETHOD scalingMethod) { m_scalingMethod = scalingMethod; }
-  
+  const std::string &VideoFilter() const { return m_videoFilter; }
+  void SetVideoFilter(const std::string &videoFilter) { m_videoFilter = videoFilter; }
+
   enum ViewMode ViewMode() const { return m_viewMode; }
   void SetViewMode(enum ViewMode viewMode) { m_viewMode = viewMode; }
 
 private:
   // Video settings
-  ESCALINGMETHOD m_scalingMethod;
+  std::string m_videoFilter;
   enum ViewMode m_viewMode;
 };

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -157,9 +157,9 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   pElement = settings->FirstChildElement("defaultgamesettings");
   if (pElement != nullptr)
   {
-    int scalingMethod;
-    if (XMLUtils::GetInt(pElement, "scalingmethod", scalingMethod, VS_SCALINGMETHOD_NEAREST, VS_SCALINGMETHOD_MAX))
-      m_defaultGameSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
+    std::string videoFilter;
+    if (XMLUtils::GetString(pElement, "videofilter", videoFilter))
+      m_defaultGameSettings.SetVideoFilter(videoFilter);
 
     int viewMode;
     if (XMLUtils::GetInt(pElement, "viewmode", viewMode, ViewModeNormal, ViewModeZoom110Width))
@@ -273,7 +273,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
   if (pNode == nullptr)
     return false;
 
-  XMLUtils::SetInt(pNode, "scalingmethod", m_defaultGameSettings.ScalingMethod());
+  XMLUtils::SetString(pNode, "videofilter", m_defaultGameSettings.VideoFilter());
   XMLUtils::SetInt(pNode, "viewmode", m_defaultGameSettings.ViewMode());
 
   // mymusic


### PR DESCRIPTION
This PR modernizes the API header (removes trailing _, other misc. changes) and encapsulates shader presets in a new class to avoid C-style calls to the add-on class.

Untested. Requires minor updates to game.shader.presets.