### PR TITLE
RetroPlayer: Fix paths

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -17,6 +17,7 @@
   <addon>kodi.binary.instance.peripheral</addon>
   <addon>kodi.binary.instance.pvr</addon>
   <addon>kodi.binary.instance.screensaver</addon>
+  <addon>kodi.binary.instance.shaderpreset</addon>
   <addon>kodi.binary.instance.vfs</addon>
   <addon>kodi.binary.instance.videocodec</addon>
   <addon>kodi.binary.instance.visualization</addon>

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -116,7 +116,7 @@ void CShaderPresetAddon::ResetProperties(void)
   m_struct.toKodi.kodiInstance = this;
 }
 
-bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, KODI::SHADER::VideoShaderPreset &shaderPreset)
+bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, SHADER::VideoShaderPreset &shaderPreset)
 {
   bool bSuccess = false;
 
@@ -145,13 +145,13 @@ bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, KODI::SHADER:
   return bSuccess;
 }
 
-void CShaderPresetAddon::TranslateShaderPreset(const video_shader &shader, KODI::SHADER::VideoShaderPreset &shaderPreset)
+void CShaderPresetAddon::TranslateShaderPreset(const video_shader &shader, SHADER::VideoShaderPreset &shaderPreset)
 {
   if (shader.passes != nullptr)
   {
     for (unsigned int i = 0; i < shader.pass_count; i++)
     {
-      KODI::SHADER::VideoShaderPass shaderPass;
+      SHADER::VideoShaderPass shaderPass;
       TranslateShaderPass(shader.passes[i], shaderPass);
       shaderPreset.passes.emplace_back(std::move(shaderPass));
     }
@@ -161,7 +161,7 @@ void CShaderPresetAddon::TranslateShaderPreset(const video_shader &shader, KODI:
   {
     for (unsigned int i = 0; i < shader.lut_count; i++)
     {
-      KODI::SHADER::VideoShaderLut shaderLut;
+      SHADER::VideoShaderLut shaderLut;
       TranslateShaderLut(shader.luts[i], shaderLut);
       shaderPreset.luts.emplace_back(std::move(shaderLut));
     }
@@ -171,14 +171,14 @@ void CShaderPresetAddon::TranslateShaderPreset(const video_shader &shader, KODI:
   {
     for (unsigned int i = 0; i < shader.parameter_count; i++)
     {
-      KODI::SHADER::VideoShaderParameter shaderParam;
+      SHADER::VideoShaderParameter shaderParam;
       TranslateShaderParameter(shader.parameters[i], shaderParam);
       shaderPreset.parameters.emplace_back(std::move(shaderParam));
     }
   }
 }
 
-void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass &pass, KODI::SHADER::VideoShaderPass &shaderPass)
+void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass &pass, SHADER::VideoShaderPass &shaderPass)
 {
   shaderPass.sourcePath = pass.source_path ? pass.source_path : "";
   shaderPass.vertexSource = pass.vertex_source ? pass.vertex_source : "";
@@ -214,7 +214,7 @@ void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass &pass, KODI
   shaderPass.mipmap = pass.mipmap;
 }
 
-void CShaderPresetAddon::TranslateShaderLut(const video_shader_lut &lut, KODI::SHADER::VideoShaderLut &shaderLut)
+void CShaderPresetAddon::TranslateShaderLut(const video_shader_lut &lut, SHADER::VideoShaderLut &shaderLut)
 {
   shaderLut.strId = lut.id ? lut.id : "";
   shaderLut.path = lut.path ? lut.path : "";
@@ -223,7 +223,7 @@ void CShaderPresetAddon::TranslateShaderLut(const video_shader_lut &lut, KODI::S
   shaderLut.mipmap = lut.mipmap;
 }
 
-void CShaderPresetAddon::TranslateShaderParameter(const video_shader_parameter &param, KODI::SHADER::VideoShaderParameter &shaderParam)
+void CShaderPresetAddon::TranslateShaderParameter(const video_shader_parameter &param, SHADER::VideoShaderParameter &shaderParam)
 {
   shaderParam.strId = param.id ? param.id : "";
   shaderParam.description = param.desc ? param.desc : "";

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -203,7 +203,9 @@ const std::string& CRPRenderManager::GetShaderPreset()
   CRPWinRenderer* winRenderer = nullptr;
   if ((winRenderer = dynamic_cast<CRPWinRenderer*>(m_pRenderer)))
     return winRenderer->GetShaderPreset();
-  return "";
+
+  static const std::string empty;
+  return empty;
 }
 
 ViewMode CRPRenderManager::GetRenderViewMode()

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -28,6 +28,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "cores/RetroPlayer/RetroPlayer.h"
 #include "guilib/GraphicContext.h"
+#include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/VideoSettings.h"
 
@@ -59,6 +60,8 @@ void CRPRenderManager::PreInit()
   m_QueueSize = 2;
   m_QueueSkip = 0;
   m_presentstep = PRESENT_IDLE;
+
+  SetShaderPreset(CMediaSettings::GetInstance().GetCurrentGameSettings().VideoFilter());
 }
 
 void CRPRenderManager::CreateRenderer()

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -32,18 +32,6 @@ CRPWinRenderer::CRPWinRenderer()
   : CWinRenderer()
   , m_shadersNeedUpdate(true)
 {
-  SetShaderPreset("ntsc/ntsc.cgp");
-  //SetShaderPreset("cgp/gameboy-screen-grid.cgp");
-  //SetShaderPreset("borders/gameboy-player/gameboy-player+crt-easymode.cgp");
-  //SetShaderPreset("reshade/lut.cgp");
-  //SetShaderPreset("borders/color-grid.cgp");
-  //SetShaderPreset("borders/mudlord.cgp");
-  //SetShaderPreset("crt/4xbr-hybrid-crt.cgp");
-  //SetShaderPreset("crt/4xbr-hybrid-crt-b.cgp");
-  //SetShaderPreset("anti-aliasing/reverse-aa.cgp");
-  //SetShaderPreset("bilinear.cgp");
-  //SetShaderPreset("nearest.cgp");
-  //SetShaderPreset("crt/shaders/phosphor.cgp");
 }
 
 CRPWinRenderer::~CRPWinRenderer()

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderManager.cpp
@@ -119,10 +119,6 @@ bool CVideoShaderManager::Update()
 
     DisposeVideoShaders();
 
-    static const auto shaderFormat = "hlsl";  // "hlsl" or "glsl" - Windows uses HLSL shaders
-    // todo: Kodi probably shouldn't know about the add-on's relative path below
-    auto presetPath = URIUtils::AddFileToFolder("resources/libretro", shaderFormat, m_videoShaderPath);
-
     if(!m_pPreset)
       m_pPreset.reset(new SHADERPRESET::CVideoShaderPreset());
 
@@ -130,9 +126,9 @@ bool CVideoShaderManager::Update()
     if (!m_pPreset->Init())
       return false;
 
-    if (!m_pPreset->ReadPresetFile(presetPath))
+    if (!m_pPreset->ReadPresetFile(m_videoShaderPath))
     {
-      CLog::Log(LOGERROR, "%s - couldn't load shader preset %s or the shaders it references", __FUNCTION__, presetPath);
+      CLog::Log(LOGERROR, "%s - couldn't load shader preset %s or the shaders it references", __FUNCTION__, m_videoShaderPath.c_str());
       return false;
     }
 
@@ -290,8 +286,6 @@ bool CVideoShaderManager::CreateShaders()
   auto numPasses = m_pPreset->Preset().passes.size();
   auto numParameters = m_pPreset->Preset().parameters.size();
   m_textureSize = GetOptimalTextureSize(m_videoSize); // todo: replace with per-shader texture size
-  // TODO: Bad! Should pass full paths at add-on side like we did with shader paths
-  auto presetDirectory = URIUtils::AddFileToFolder("special://xbmcbinaddons/game.shader.presets/resources/libretro/hlsl", m_videoShaderPath);
 
   // todo: is this pass specific?
   ShaderLUTs passLUTs;
@@ -300,7 +294,7 @@ bool CVideoShaderManager::CreateShaders()
     const VideoShaderLut& lutStruct = m_pPreset->Preset().luts[i];
 
     ID3D11SamplerState* lutSampler(CreateLUTSampler(lutStruct));
-    CDXTexture* lutTexture(CreateLUTexture(lutStruct, presetDirectory));
+    CDXTexture* lutTexture(CreateLUTexture(lutStruct, m_videoShaderPath));
 
     if (!lutSampler || !lutTexture)
     {

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
@@ -56,7 +56,7 @@ void CVideoShaderPresetFactory::RegisterLoader(IVideoShaderPresetLoader *loader,
     if (extension[0] != '.')
       strExtension.insert(strExtension.begin(), '.');
 
-    m_loaders.insert(std::make_pair(std::move(extension), loader));
+    m_loaders.insert(std::make_pair(std::move(strExtension), loader));
   }
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.cpp
@@ -124,7 +124,7 @@ void CVideoShaderPresetFactory::UpdateAddons()
       [&shaderAddon](const std::unique_ptr<CShaderPresetAddon> &addon)
       {
         return shaderAddon->ID() == addon->ID();
-      }) != m_shaderAddons.end();
+      }) == m_shaderAddons.end();
 
     if (bIsNew)
     {

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -25,9 +25,11 @@
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XBMCTinyXML.h"
 #include "FileItem.h"
+#include "URL.h"
 
 #include <stdlib.h>
 
@@ -48,12 +50,13 @@ void CDialogGameVideoFilter::PreInit()
   // TODO: Have the add-on give us the xml as a string (or parse it)
   static const std::string addonPath = std::string("special://xbmcbinaddons/") + PRESETS_ADDON_NAME;
   static const std::string xmlPath = addonPath + "/resources/ShaderPresetsDefault.xml";
+  std::string basePath = URIUtils::GetBasePath(xmlPath);
 
   CXBMCTinyXML xml = CXBMCTinyXML(xmlPath);
 
   if (!xml.LoadFile())
   {
-    CLog::Log(LOGERROR, "%s - Couldn't load shader presets default .xml, %s", __FUNCTION__, xmlPath);
+    CLog::Log(LOGERROR, "%s - Couldn't load shader presets default .xml, %s", __FUNCTION__, CURL::GetRedacted(xmlPath).c_str());
     return;
   }
 
@@ -64,7 +67,7 @@ void CDialogGameVideoFilter::PreInit()
   {
     VideoFilterProperties videoFilter;
 
-    videoFilter.path = addonPath + "/resources/libretro/hlsl/" + child->FirstChild("path")->FirstChild()->Value();
+    videoFilter.path = URIUtils::AddFileToFolder(basePath, child->FirstChild("path")->FirstChild()->Value());
     videoFilter.nameIndex = atoi(child->FirstChild("name")->FirstChild()->Value());
     videoFilter.categoryIndex = atoi(child->FirstChild("category")->FirstChild()->Value());
     videoFilter.descriptionIndex = atoi(child->FirstChild("description")->FirstChild()->Value());
@@ -72,7 +75,7 @@ void CDialogGameVideoFilter::PreInit()
     m_videoFilters.emplace_back(videoFilter);
   }
 
-  CLog::Log(LOGDEBUG, "%s - Loaded shader presets default .xml, %s", __FUNCTION__, xmlPath);
+  CLog::Log(LOGDEBUG, "Loaded %d shader presets default .xml, %s", m_videoFilters.size(), CURL::GetRedacted(xmlPath).c_str());
 }
 
 void CDialogGameVideoFilter::GetItems(CFileItemList &items)


### PR DESCRIPTION
This fixes the use of relative paths, and a few other bugs from the last PR, #6.