### PR TITLE
RetroPlayaer: Fix missing call to CreateAddon()

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaderPresetFactory.h
@@ -71,6 +71,7 @@ namespace SHADER
 
     std::map<std::string, IVideoShaderPresetLoader*> m_loaders;
     std::vector<std::unique_ptr<ADDON::CShaderPresetAddon>> m_shaderAddons;
+    std::vector<std::unique_ptr<ADDON::CShaderPresetAddon>> m_failedAddons;
   };
 }
 }


### PR DESCRIPTION
Fixes another problem with my PR #6.

Shaders seem to be loaded successfully now. Next, we need to modify the add-on to resolve relative paths for shaders and LUTs.