### PR TITLE
Shader API: Rename config file to preset file

### DIFF
--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -30,7 +30,7 @@ using namespace ADDON;
 
 // --- CShaderPreset -----------------------------------------------------------
 
-CShaderPreset::CShaderPreset(config_file *file, AddonInstance_ShaderPreset &instanceStruct) :
+CShaderPreset::CShaderPreset(preset_file file, AddonInstance_ShaderPreset &instanceStruct) :
   m_file(file),
   m_struct(instanceStruct)
 {
@@ -38,7 +38,7 @@ CShaderPreset::CShaderPreset(config_file *file, AddonInstance_ShaderPreset &inst
 
 CShaderPreset::~CShaderPreset()
 {
-  m_struct.toAddon.config_file_free(&m_struct, m_file);
+  m_struct.toAddon.preset_file_free(&m_struct, m_file);
 }
 
 bool CShaderPreset::ReadShaderPreset(video_shader &shader)
@@ -122,7 +122,7 @@ bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, SHADER::Video
 
   std::string translatedPath = CSpecialProtocol::TranslatePath(presetPath);
 
-  config_file *file = m_struct.toAddon.config_file_new(&m_struct, translatedPath.c_str());
+  preset_file file = m_struct.toAddon.preset_file_new(&m_struct, translatedPath.c_str());
 
   if (file != nullptr)
   {
@@ -139,7 +139,7 @@ bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, SHADER::Video
       shaderPresetAddon->FreeShaderPreset(videoShader);
     }
 
-    m_struct.toAddon.config_file_free(&m_struct, file);
+    m_struct.toAddon.preset_file_free(&m_struct, file);
   }
 
   return bSuccess;

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -35,7 +35,7 @@ namespace ADDON
   class CShaderPreset
   {
   public:
-    CShaderPreset(config_file *file, AddonInstance_ShaderPreset &instanceStruct);
+    CShaderPreset(preset_file file, AddonInstance_ShaderPreset &instanceStruct);
     ~CShaderPreset();
 
     /*!
@@ -60,7 +60,7 @@ namespace ADDON
     void FreeShaderPreset(video_shader &shader);
 
   private:
-    config_file *m_file;
+    preset_file m_file;
     AddonInstance_ShaderPreset &m_struct;
   };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -142,8 +142,8 @@
                                                       "StreamCodec.h" \
                                                       "StreamCrypto.h"
 
-#define ADDON_INSTANCE_VERSION_SHADERPRESET           "0.0.3"
-#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "0.0.3"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET           "0.0.4"
+#define ADDON_INSTANCE_VERSION_SHADERPRESET_MIN       "0.0.4"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_XML_ID    "kodi.binary.instance.shaderpreset"
 #define ADDON_INSTANCE_VERSION_SHADERPRESET_DEPENDS   "addon-instance/ShaderPreset.h"
 


### PR DESCRIPTION
This is centered around a change I made:

```c++
typedef struct config_file config_file;
```

to

```c++
typedef void *preset_file;
```

The reason for this is to allow the add-on to use `static_cast` instead of `reinterpret_cast`.