### PR TITLE
RetroPlayer: Revert "Fix resource leak in shader add-on"

### DIFF
--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -138,8 +138,6 @@ bool CShaderPresetAddon::LoadPreset(const std::string &presetPath, SHADER::Video
       }
       shaderPresetAddon->FreeShaderPreset(videoShader);
     }
-
-    m_struct.toAddon.preset_file_free(&m_struct, file);
   }
 
   return bSuccess;


### PR DESCRIPTION
This reverts a "fix" that actually caused a double free. Note that while the fix is correct, it hasn't fixed the mem corruption I'm seeing.