### PR TITLE
Fix compilation on OSX

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -48,6 +48,7 @@ namespace RETRO
     void Flush() override;
     void RenderUpdate(bool clear, unsigned int alpha) override;
     void Deinitialize() override;
+    void SetSpeed(double speed) override { }
     bool Supports(ERENDERFEATURE feature) const override;
     bool Supports(ESCALINGMETHOD method) const override;
 


### PR DESCRIPTION
With this change, OSX compiles and plays games (though without filters obviously)