### PR TITLE
Add scaling methods to video filters (work-in-progress)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8710,7 +8710,19 @@ msgctxt "#16206"
 msgid "Failed to delete at least one file. Check the log for more information about this message."
 msgstr ""
 
-#empty strings from id 16207 to 16299
+#empty strings from id 16207 to 16297
+
+#. Name of the video filter that uses jagged pixels without smoothing
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16298"
+msgid "Pixelate"
+msgstr ""
+
+#. Name of the video filter that blurs pixels to remove jagged edges
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16299"
+msgid "Blur"
+msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16300"

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -188,8 +188,9 @@
 						<control type="gamewindow">
 							<width>444</width>
 							<height>250</height>
-							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
 							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
 						</control>
 						<control type="label">
 							<top>250</top>
@@ -218,8 +219,9 @@
 						<control type="gamewindow">
 							<width>444</width>
 							<height>250</height>
-							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
 							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
 						</control>
 						<control type="label">
 							<top>250</top>

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -50,7 +50,7 @@ void CGUIGameControl::SetVideoFilter(const CGUIInfoLabel &videoFilter)
 
 void CGUIGameControl::SetScalingMethod(const CGUIInfoLabel &scalingMode)
 {
-  m_scalingModeInfo = scalingMode;
+  m_scalingMethodInfo = scalingMode;
 }
 
 void CGUIGameControl::SetViewMode(const CGUIInfoLabel &viewMode)
@@ -138,6 +138,14 @@ void CGUIGameControl::UpdateInfo(const CGUIListItem *item /* = nullptr */)
     if (!videoFilter.empty())
       m_renderSettings.SetVideoFilter(videoFilter);
 
+    std::string strScalingMethod = m_scalingMethodInfo.GetItemLabel(item);
+    if (StringUtils::IsNaturalNumber(strScalingMethod))
+    {
+      unsigned int scalingMethod;
+      std::istringstream(std::move(strScalingMethod)) >> scalingMethod;
+      m_renderSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
+    }
+
     std::string strViewMode = m_viewModeInfo.GetItemLabel(item);
     if (StringUtils::IsNaturalNumber(strViewMode))
     {
@@ -145,7 +153,6 @@ void CGUIGameControl::UpdateInfo(const CGUIListItem *item /* = nullptr */)
       std::istringstream(std::move(strViewMode)) >> viewMode;
       m_renderSettings.SetRenderViewMode(static_cast<ViewMode>(viewMode));
     }
-    // todo: scaling mode
   }
 }
 

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
@@ -37,7 +37,7 @@ public:
   ~CGUIGameControl() override = default;
 
   void SetVideoFilter(const CGUIInfoLabel &videoFilter);
-  void SetScalingMethod(const CGUIInfoLabel &scalingMode);
+  void SetScalingMethod(const CGUIInfoLabel &scalingMethod);
   void SetViewMode(const CGUIInfoLabel &viewMode);
 
   const CGUIRenderSettings &GetRenderSettings() const { return m_renderSettings; }
@@ -55,7 +55,7 @@ private:
   void DisableGUIRender();
 
   CGUIInfoLabel m_videoFilterInfo;
-  CGUIInfoLabel m_scalingModeInfo;
+  CGUIInfoLabel m_scalingMethodInfo;
   CGUIInfoLabel m_viewModeInfo;
 
   CGUIRenderSettings m_renderSettings;

--- a/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.cpp
@@ -48,10 +48,10 @@ std::string CGUIRenderSettings::GetVideoFilter() const
   return gameSettings.VideoFilter();
 }
 
-int CGUIRenderSettings::GetScalingMethod() const
+ESCALINGMETHOD CGUIRenderSettings::GetScalingMethod() const
 {
   if (HasScalingMethod())
-    return m_scalingMethod;
+    return static_cast<ESCALINGMETHOD>(m_scalingMethod);
 
   CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
   return gameSettings.ScalingMethod();

--- a/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.h
+++ b/xbmc/cores/RetroPlayer/rendering/GUIRenderSettings.h
@@ -39,7 +39,7 @@ namespace RETRO
     void SetVideoFilter(const std::string &videoFilter) { m_videoFilter = videoFilter; }
     void ResetVideoFilter() { m_videoFilter.clear(); }
 
-    int GetScalingMethod() const;
+    ESCALINGMETHOD GetScalingMethod() const;
     bool HasScalingMethod() const { return m_scalingMethod != -1; }
     void SetScalingMethod(ESCALINGMETHOD method) { m_scalingMethod = static_cast<int>(method); }
     void ResetScalingMethod() { m_scalingMethod = -1; }

--- a/xbmc/cores/RetroPlayer/rendering/IRenderSettingsCallback.h
+++ b/xbmc/cores/RetroPlayer/rendering/IRenderSettingsCallback.h
@@ -34,14 +34,14 @@ namespace RETRO
     virtual bool SupportsRenderFeature(ERENDERFEATURE feature) const = 0;
     virtual bool SupportsScalingMethod(ESCALINGMETHOD method) const = 0;
 
+    virtual void SetShaderPreset(const std::string& shaderPresetPath) = 0;
+    virtual const std::string &GetShaderPreset() const = 0;
+
     virtual ESCALINGMETHOD GetScalingMethod() const = 0;
     virtual void SetScalingMethod(ESCALINGMETHOD scalingMethod) = 0;
 
     virtual ViewMode GetRenderViewMode() const = 0;
     virtual void SetRenderViewMode(ViewMode mode) = 0;
-
-    virtual void SetShaderPreset(const std::string& shaderPresetPath) = 0;
-    virtual const std::string &GetShaderPreset() const = 0;
   };
 }
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -21,6 +21,7 @@
 
 #include "DialogGameVideoSelect.h"
 #include "cores/IPlayer.h"
+#include "FileItem.h"
 
 namespace KODI
 {
@@ -41,6 +42,12 @@ namespace GAME
     void PostExit() override;
 
   private:
+    void InitScalingMethods();
+    void InitVideoFilters();
+
+    static std::string GetLocalizedString(uint32_t code);
+    static void GetProperties(const CFileItem &item, std::string &videoPreset, ESCALINGMETHOD &scalingMethod);
+
     struct VideoFilterProperties
     {
       std::string path;
@@ -49,9 +56,7 @@ namespace GAME
       int descriptionIndex;
     };
 
-    std::vector<VideoFilterProperties> m_videoFilters;
-
-    static std::string GetLocalizedString(uint32_t code);
+    CFileItemList m_items;
   };
 }
 }

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1149,13 +1149,17 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
       control = new CGUIGameControl(parentID, id, posX, posY, width, height);
 
-      CGUIInfoLabel viewMode;
-      GetInfoLabel(pControlNode, "viewmode", viewMode, parentID);
-      static_cast<CGUIGameControl*>(control)->SetViewMode(viewMode);
-
       CGUIInfoLabel videoFilter;
       GetInfoLabel(pControlNode, "videofilter", videoFilter, parentID);
       static_cast<CGUIGameControl*>(control)->SetVideoFilter(videoFilter);
+
+      CGUIInfoLabel scalingMethod;
+      GetInfoLabel(pControlNode, "scalingMethod", scalingMethod, parentID);
+      static_cast<CGUIGameControl*>(control)->SetScalingMethod(scalingMethod);
+
+      CGUIInfoLabel viewMode;
+      GetInfoLabel(pControlNode, "viewmode", viewMode, parentID);
+      static_cast<CGUIGameControl*>(control)->SetViewMode(viewMode);
     }
     break;
   case CGUIControl::GUICONTROL_FADELABEL:

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -161,6 +161,10 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
     if (XMLUtils::GetString(pElement, "videofilter", videoFilter))
       m_defaultGameSettings.SetVideoFilter(videoFilter);
 
+    int scalingMethod;
+    if (XMLUtils::GetInt(pElement, "scalingmethod", scalingMethod, VS_SCALINGMETHOD_NEAREST, VS_SCALINGMETHOD_LINEAR))
+      m_defaultGameSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
+
     int viewMode;
     if (XMLUtils::GetInt(pElement, "viewmode", viewMode, ViewModeNormal, ViewModeZoom110Width))
       m_defaultGameSettings.SetViewMode(static_cast<ViewMode>(viewMode));
@@ -274,6 +278,7 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
     return false;
 
   XMLUtils::SetString(pNode, "videofilter", m_defaultGameSettings.VideoFilter());
+  XMLUtils::SetInt(pNode, "scalingmethod", m_defaultGameSettings.ScalingMethod());
   XMLUtils::SetInt(pNode, "viewmode", m_defaultGameSettings.ViewMode());
 
   // mymusic


### PR DESCRIPTION
This prepends "Pixelate" and "Blur" filters to the list of video filters, if supported by the default renderer. These use the scaling method parameter with an empty shader preset string.

As a result, with no shaders present, the user still has access to these two basic filters.

Currently, RP fails to change from a preset to a scaling method because presets assume that once active, shader presets are always active.