### PR TITLE
Fix renderer not loading preset on game start

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8718,10 +8718,10 @@ msgctxt "#16298"
 msgid "Pixelate"
 msgstr ""
 
-#. Name of the video filter that blurs pixels to remove jagged edges
+#. Name of the video filter that smooths pixels to remove jagged edges
 #: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
 msgctxt "#16299"
-msgid "Blur"
+msgid "Smooth"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -179,7 +179,7 @@ void CShaderPresetAddon::TranslateShaderPreset(const video_shader &shader, SHADE
   }
 }
 
-void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass &pass, VideoShaderPass &shaderPass)
+void CShaderPresetAddon::TranslateShaderPass(const video_shader_pass &pass, SHADER::VideoShaderPass &shaderPass)
 {
   shaderPass.sourcePath = pass.source_path ? pass.source_path : "";
   shaderPass.vertexSource = pass.vertex_source ? pass.vertex_source : "";

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -27,8 +27,6 @@
 #include <string>
 #include <vector>
 
-struct cp_extension_t;
-
 using namespace KODI;
 using namespace SHADER;
 

--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -27,9 +27,6 @@
 #include <string>
 #include <vector>
 
-using namespace KODI;
-using namespace SHADER;
-
 namespace ADDON
 {
   class CShaderPreset
@@ -68,7 +65,7 @@ namespace ADDON
    *  Wrapper class that wraps the shader presets add-on
    */
   class CShaderPresetAddon : public IAddonInstanceHandler,
-                             public IVideoShaderPresetLoader
+                             public KODI::SHADER::IVideoShaderPresetLoader
   {
   public:
     CShaderPresetAddon(const BinaryAddonBasePtr& addonInfo);
@@ -90,7 +87,7 @@ namespace ADDON
     const std::vector<std::string> &GetExtensions() const { return m_extensions; }
 
     // implementation of IVideoShaderPresetLoader
-    bool LoadPreset(const std::string &presetPath, SHADER::IVideoShaderPreset &shaderPreset) override;
+    bool LoadPreset(const std::string &presetPath, KODI::SHADER::IVideoShaderPreset &shaderPreset) override;
 
   private:
     /*!
@@ -98,13 +95,13 @@ namespace ADDON
      */
     void ResetProperties(void);
 
-    static void TranslateShaderPreset(const video_shader &shader, SHADER::IVideoShaderPreset& shaderPreset);
-    static void TranslateShaderPass(const video_shader_pass &pass, VideoShaderPass &shaderPass);
-    static void TranslateShaderLut(const video_shader_lut &lut, VideoShaderLut &shaderLut);
-    static void TranslateShaderParameter(const video_shader_parameter &param, VideoShaderParameter &shaderParam);
-    static FILTER_TYPE TranslateFilterType(SHADER_FILTER_TYPE type);
-    static WRAP_TYPE TranslateWrapType(SHADER_WRAP_TYPE type);
-    static SCALE_TYPE TranslateScaleType(SHADER_SCALE_TYPE type);
+    static void TranslateShaderPreset(const video_shader &shader, KODI::SHADER::IVideoShaderPreset& shaderPreset);
+    static void TranslateShaderPass(const video_shader_pass &pass, KODI::SHADER::VideoShaderPass &shaderPass);
+    static void TranslateShaderLut(const video_shader_lut &lut, KODI::SHADER::VideoShaderLut &shaderLut);
+    static void TranslateShaderParameter(const video_shader_parameter &param, KODI::SHADER::VideoShaderParameter &shaderParam);
+    static KODI::SHADER::FILTER_TYPE TranslateFilterType(SHADER_FILTER_TYPE type);
+    static KODI::SHADER::WRAP_TYPE TranslateWrapType(SHADER_WRAP_TYPE type);
+    static KODI::SHADER::SCALE_TYPE TranslateScaleType(SHADER_SCALE_TYPE type);
 
     /* @brief Cache for const char* members in PERIPHERAL_PROPERTIES */
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -55,6 +55,8 @@ void CRPBaseRenderer::LoadGameSettings()
 {
   CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
 
+  // Transfer GUI settings to renderer
+  SetShaderPreset(gameSettings.VideoFilter());
   SetScalingMethod(gameSettings.ScalingMethod());
   SetViewMode(gameSettings.ViewMode());
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -154,7 +154,7 @@ void CDialogGameVideoFilter::GetItems(CFileItemList &items)
 
 void CDialogGameVideoFilter::OnItemFocus(unsigned int index)
 {
-  if (index < m_items.Size())
+  if (static_cast<int>(index) < m_items.Size())
   {
     CFileItemPtr item = m_items[index];
 
@@ -183,7 +183,7 @@ unsigned int CDialogGameVideoFilter::GetFocusedItem() const
 {
   CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
 
-  for (unsigned int i = 0; i < m_items.Size(); i++)
+  for (int i = 0; i < m_items.Size(); i++)
   {
     std::string presetToSet;
     ESCALINGMETHOD scalingMethod;


### PR DESCRIPTION
Fixes the renderer not loading the last preset when the game is started. Also contains other minor fixes.