### PR TITLE
Add filter description to video filter dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8710,18 +8710,30 @@ msgctxt "#16206"
 msgid "Failed to delete at least one file. Check the log for more information about this message."
 msgstr ""
 
-#empty strings from id 16207 to 16297
+#empty strings from id 16207 to 16295
 
 #. Name of the video filter that uses jagged pixels without smoothing
 #: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
-msgctxt "#16298"
+msgctxt "#16296"
 msgid "Pixelate"
 msgstr ""
 
 #. Name of the video filter that smooths pixels to remove jagged edges
 #: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
-msgctxt "#16299"
+msgctxt "#16297"
 msgid "Smooth"
+msgstr ""
+
+#. Description of the video filter that uses jagged pixels without smoothing
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16298"
+msgid "Shows the game's pixels without any modifications."
+msgstr ""
+
+#. Description of the video filter that smooths pixels to remove jagged edges
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16299"
+msgid "Removes the jagged edges of pixels by evenly fading between adjacent pixels."
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -161,7 +161,7 @@
 		</control>
 		<control type="group">
 			<bottom>0</bottom>
-			<height>410</height>
+			<height>540</height>
 			<width>100%</width>
 			<control type="image">
 				<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
@@ -169,7 +169,7 @@
 				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>
 			<control type="panel" id="11">
-				<top>50</top>
+				<top>40</top>
 				<scrolltime tween="sine">200</scrolltime>
 				<orientation>horizontal</orientation>
 				<itemlayout width="480" height="340">
@@ -195,9 +195,9 @@
 						<control type="label">
 							<top>250</top>
 							<width>444</width>
-							<height>40</height>
+							<height>80</height>
 							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
-							<font>font12</font>
+							<font>font37</font>
 							<shadowcolor>text_shadow</shadowcolor>
 							<align>center</align>
 						</control>
@@ -226,9 +226,9 @@
 						<control type="label">
 							<top>250</top>
 							<width>444</width>
-							<height>40</height>
+							<height>80</height>
 							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
-							<font>font12</font>
+							<font>font37</font>
 							<shadowcolor>text_shadow</shadowcolor>
 							<align>center</align>
 						</control>
@@ -240,6 +240,17 @@
 						</control>
 					</control>
 				</focusedlayout>
+			</control>
+			<control type="textbox" id="12">
+				<description>Description Area</description>
+				<top>420</top>
+				<left>100</left>
+				<right>100</right>
+				<height>200</height>
+				<font>font27</font>
+				<align>justify</align>
+				<shadowcolor>text_shadow</shadowcolor>
+				<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
 			</control>
 		</control>
 	</include>

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -46,7 +46,7 @@ namespace GAME
     void InitVideoFilters();
 
     static std::string GetLocalizedString(uint32_t code);
-    static void GetProperties(const CFileItem &item, std::string &videoPreset, ESCALINGMETHOD &scalingMethod);
+    static void GetProperties(const CFileItem &item, std::string &videoPreset, ESCALINGMETHOD &scalingMethod, std::string &description);
 
     struct VideoFilterProperties
     {
@@ -57,6 +57,9 @@ namespace GAME
     };
 
     CFileItemList m_items;
+
+    //! \brief Set to true when a description has first been set
+    bool m_bHasDescription = false;
   };
 }
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -21,6 +21,7 @@
 #include "DialogGameVideoSelect.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIBaseContainer.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
 #include "input/Action.h"
 #include "input/ActionIDs.h"
@@ -39,6 +40,7 @@ using namespace KODI;
 using namespace GAME;
 
 #define CONTROL_THUMBS                11
+#define CONTROL_DESCRIPTION           12
 
 CDialogGameVideoSelect::CDialogGameVideoSelect(int windowId) :
   CGUIDialog(windowId, "DialogSelect.xml"),
@@ -145,6 +147,8 @@ void CDialogGameVideoSelect::OnInitWindow()
 
   CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_THUMBS);
   OnMessage(msg);
+
+  FrameMove();
 }
 
 void CDialogGameVideoSelect::OnDeinitWindow(int nextWindowID)
@@ -187,7 +191,10 @@ void CDialogGameVideoSelect::OnRefreshList()
   GetItems(*m_vecItems);
 
   m_viewControl->SetItems(*m_vecItems);
-  m_viewControl->SetSelectedItem(GetFocusedItem());
+
+  auto focusedIndex = GetFocusedItem();
+  m_viewControl->SetSelectedItem(focusedIndex);
+  OnItemFocus(focusedIndex);
 }
 
 void CDialogGameVideoSelect::SaveSettings()
@@ -200,4 +207,11 @@ void CDialogGameVideoSelect::SaveSettings()
     defaultSettings = currentSettings;
     CServiceBroker::GetSettings().Save();
   }
+}
+
+void CDialogGameVideoSelect::OnDescriptionChange(const std::string &description)
+{
+  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_DESCRIPTION);
+  msg.SetLabel(description);
+  OnMessage(msg); //! @todo OK to send from this thread?
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -65,6 +65,8 @@ namespace GAME
     virtual unsigned int GetFocusedItem() const = 0;
     virtual void PostExit() = 0;
 
+    void OnDescriptionChange(const std::string &description);
+
     RETRO::IRenderSettingsCallback *m_callback = nullptr;
 
   private:


### PR DESCRIPTION
This adds a description of the active shader to display at the bottom of the screen.

## Screenshots (if appropriate):
![screenshot005](https://user-images.githubusercontent.com/531482/29842930-2961a338-8cbf-11e7-9392-32a22afeb826.png)
