### PR TITLE
Restore view mode controls in game OSD

### DIFF
--- a/addons/skin.estuary/xml/DialogSelect.xml
+++ b/addons/skin.estuary/xml/DialogSelect.xml
@@ -4,7 +4,8 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<depth>DepthOSD</depth>
 	<controls>
-		<include condition="Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)">GameDialogSelectLayout</include>
 		<include condition="![Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)]">DefaultDialogSelectLayout</include>
+		<include condition="Window.IsActive(gamevideofilter)">GameDialogSelectFilterLayout</include>
+		<include condition="Window.IsActive(gameviewmode)">GameDialogSelectViewLayout</include>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -148,7 +148,7 @@
 			</control>
 		</control>
 	</include>
-	<include name="GameDialogSelectLayout">
+	<include name="GameDialogSelectFilterLayout">
 		<control type="button">
 			<description>background close area</description>
 			<left>0</left>
@@ -251,6 +251,101 @@
 				<align>justify</align>
 				<shadowcolor>text_shadow</shadowcolor>
 				<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
+			</control>
+		</control>
+	</include>
+	<include name="GameDialogSelectViewLayout">
+		<control type="button">
+			<description>background close area</description>
+			<left>0</left>
+			<top>0</top>
+			<width>100%</width>
+			<bottom>410</bottom>
+			<texturefocus />
+			<texturenofocus />
+			<onclick>Action(close)</onclick>
+		</control>
+		<control type="group">
+			<bottom>0</bottom>
+			<height>410</height>
+			<width>100%</width>
+			<control type="image">
+				<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
+			</control>
+			<control type="panel" id="11">
+				<top>50</top>
+				<scrolltime tween="sine">200</scrolltime>
+				<orientation>horizontal</orientation>
+				<itemlayout width="480" height="340">
+					<control type="group">
+						<left>18</left>
+						<right>18</right>
+						<top>5</top>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">DefaultVideo.png</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
+						</control>
+						<control type="label">
+							<top>250</top>
+							<width>444</width>
+							<height>40</height>
+							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
+							<font>font37</font>
+							<shadowcolor>text_shadow</shadowcolor>
+							<align>center</align>
+						</control>
+					</control>
+				</itemlayout>
+				<focusedlayout width="480" height="340">
+					<control type="group">
+						<left>18</left>
+						<right>18</right>
+						<top>5</top>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">DefaultVideo.png</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
+						</control>
+						<control type="label">
+							<top>250</top>
+							<width>444</width>
+							<height>40</height>
+							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
+							<font>font37</font>
+							<shadowcolor>text_shadow</shadowcolor>
+							<align>center</align>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
+							<visible>Control.HasFocus(11)</visible>
+						</control>
+					</control>
+				</focusedlayout>
 			</control>
 		</control>
 	</include>


### PR DESCRIPTION
This restores the shorter video selection dialog for use in selecting the view mode.

## Screenshots (if appropriate):
![screenshot006](https://user-images.githubusercontent.com/531482/29843947-83a951e4-8cc2-11e7-9791-5b3c51dc7630.png)
