### PR TITLE
Video filter dialog: Change select action

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -23,9 +23,7 @@
 #include "guilib/GUIBaseContainer.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
-#include "input/Action.h"
 #include "input/ActionIDs.h"
-#include "messaging/ApplicationMessenger.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -94,9 +92,8 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage &message)
         {
           using namespace MESSAGING;
 
-          // Send OSD command to resume gameplay
-          CAction *action = new CAction(ACTION_SHOW_OSD);
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(action));
+          // Changed from sending ACTION_SHOW_OSD to closing the dialog
+          Close();
 
           return true;
         }


### PR DESCRIPTION
The changes the Select action in the shader selection dialog to return to the previous OSD menu instead of going directly to the game.

After testing both, I'm really not sure what the best UX is. Ideas?