### PR TITLE
Build fixes for shaders branch

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADERS AudioDecoder.h
             Peripheral.h
             PeripheralUtils.h
             Screensaver.h
+            ShaderPreset.h
             VFS.h
             VideoCodec.h
             Visualization.h)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ShaderPreset.h
@@ -332,8 +332,8 @@ namespace kodi
        *
        * \param shader            Shader pass handle
        * \param ref_path          Relative shader path
-       *
-      virtual void ShaderPresetResolveRelative(video_shader &shader, const char *ref_path) { }
+       */
+      //virtual void ShaderPresetResolveRelative(video_shader &shader, const char *ref_path) { }
 
       /*!
        * \brief Read the current value for all parameters from preset file
@@ -342,8 +342,8 @@ namespace kodi
        * \param shader            Shader passes handle
        *
        * \return True if successful, otherwise false
-       *
-      virtual bool ShaderPresetResolveCurrentParameters(preset_file file, video_shader &shader) { return false; }
+       */
+      //virtual bool ShaderPresetResolveCurrentParameters(preset_file file, video_shader &shader) { return false; }
 
       /*!
        * \brief Resolve all shader parameters belonging to the shader preset


### PR DESCRIPTION
## Description

Had some time this weekend for shader testing, which resulted in the two build fixes here. The first fixes ShaderPreset.h missing from the VS project, and the second fixes jenkins CI builds on non-windows platforms.

## Motivation and Context
While rebasing kostas's and your work for testing against master.

## How Has This Been Tested?
Test builds here: https://github.com/garbear/xbmc/releases/tag/retroplayer-18.5-20200126

## Screenshots (if appropriate):

Windows screenshot from this branch rebased against 18.5:

![screenshot000](https://user-images.githubusercontent.com/531482/73147862-5ed7c280-406e-11ea-8cf3-583fdc2dc3dc.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
