### PR TITLE
Fix changing from shaders back to scalers

### DIFF
--- a/xbmc/addons/ShaderPreset.h
+++ b/xbmc/addons/ShaderPreset.h
@@ -103,19 +103,8 @@ namespace ADDON
     static KODI::SHADER::WRAP_TYPE TranslateWrapType(SHADER_WRAP_TYPE type);
     static KODI::SHADER::SCALE_TYPE TranslateScaleType(SHADER_SCALE_TYPE type);
 
-    /* \brief Cache for const char* members in PERIPHERAL_PROPERTIES */
-
-    std::string         m_strLibraryPath;
-    std::string         m_strConfigPath;
-    std::string         m_strConfigBasePath;
-    std::string         m_strUserPath;    /*!< @brief translated path to the user profile */
-    std::string         m_strClientPath;  /*!< @brief translated path to this add-on */
-
     /* \brief Add-on properties */
     std::vector<std::string> m_extensions;
-
-    /* \brief Thread synchronization */
-    CCriticalSection    m_critSection;
 
     AddonInstance_ShaderPreset m_struct;
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.cpp
@@ -78,10 +78,12 @@ void CRenderVideoSettings::SetVideoFilter(const std::string &videoFilter)
   if (videoFilter == VIDEO_FILTER_NEAREST)
   {
     m_scalingMethod = SCALINGMETHOD::NEAREST;
+    ResetShaderPreset();
   }
   else if (videoFilter == VIDEO_FILTER_LINEAR)
   {
     m_scalingMethod = SCALINGMETHOD::LINEAR;
+    ResetShaderPreset();
   }
   else
   {
@@ -90,6 +92,11 @@ void CRenderVideoSettings::SetVideoFilter(const std::string &videoFilter)
     // Not a known video filter, assume it's a shader preset path
     SetShaderPreset(videoFilter);
   }
+}
+
+void CRenderVideoSettings::ResetShaderPreset()
+{
+  m_shaderPreset.clear();
 }
 
 bool CRenderVideoSettings::UsesShaderPreset() const

--- a/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
@@ -45,6 +45,7 @@ namespace RETRO
 
     const std::string &GetShaderPreset() const { return m_shaderPreset; }
     void SetShaderPreset(const std::string &shaderPreset) { m_shaderPreset = shaderPreset; }
+    void ResetShaderPreset();
 
     unsigned int GetRenderRotation() const { return m_rotationDegCCW; }
     void SetRenderRotation(unsigned int rotationDegCCW) { m_rotationDegCCW = rotationDegCCW; }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -82,10 +82,12 @@ void CDialogGameVideoFilter::InitScalingMethods()
     {
       if (m_gameVideoHandle->SupportsScalingMethod(scalingMethodProps.scalingMethod))
       {
+        RETRO::CRenderVideoSettings videoSettings;
+        videoSettings.SetScalingMethod(scalingMethodProps.scalingMethod);
+
         CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
         item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
-        item->SetProperty("game.videofilter", CVariant{ PROPERTY_NO_VIDEO_FILTER });
-        item->SetProperty("game.scalingmethod", CVariant((int)scalingMethodProps.scalingMethod));
+        item->SetProperty("game.videofilter", CVariant{ videoSettings.GetVideoFilter() });
         item->SetProperty("game.videofilterdescription", CVariant{ g_localizeStrings.Get(scalingMethodProps.descriptionIndex) });
         m_items.Add(std::move(item));
       }


### PR DESCRIPTION
## Description

This PR fixes the nearest-neighbor and bilinear scalers after switching in the Video Filter dialog.  When moving from a shader to a non-shader, the preset string isn't reset, so the scaling method is ignored. The ListItem properties were also updated.

Also includes a code improvement by removing variables leftover from the C++ API migration.

## How Has This Been Tested?

Moved to a shader, then moved back to Bilinear. Verified that the fullscreen game window used the scaling method without a shader preset.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
